### PR TITLE
Fix CI failures by downgrading actions/checkout from v6 to v4

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -11,10 +11,10 @@ jobs:
         run: rm -rf "${{ github.workspace }}"/*
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Checkout secrets repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: bensuskins/secrets
           path: secrets

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: terraform
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -56,7 +56,7 @@ jobs:
         working-directory: terraform
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,10 +13,10 @@ jobs:
         run: rm -rf "${{ github.workspace }}"/*
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Checkout secrets repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: bensuskins/secrets
           path: secrets


### PR DESCRIPTION
actions/checkout@v6 does not exist; v4 is the current stable release.

https://claude.ai/code/session_014kYUkhHEn3ohvi56pL3wsf