### PR TITLE
Fix CI failures in Terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: sudo apt-get install -y unzip
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
@@ -57,6 +60,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get install -y unzip
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## Summary

- Replace non-existent `actions/checkout@v6` with `@v4` across all workflow files (`terraform.yml`, `update.yml`, `clean.yml`)
- Install `unzip` before `hashicorp/setup-terraform` in both `plan` and `apply` jobs, as the action requires it to extract the Terraform binary on the self-hosted runner

## Test plan

- [ ] Terraform workflow `plan` job completes without error
- [ ] Terraform workflow `apply` job completes without error
- [ ] Update and Clean workflows check out successfully

https://claude.ai/code/session_014kYUkhHEn3ohvi56pL3wsf