### PR TITLE
Move Terraform workflow to GitHub-hosted runner

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,16 +9,13 @@ on:
 
 jobs:
   plan:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: terraform
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: sudo apt-get install -y unzip
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -51,7 +48,7 @@ jobs:
           path: terraform/tfplan
 
   apply:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: plan
     environment: production
     defaults:
@@ -60,9 +57,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: sudo apt-get install -y unzip
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## Summary

- Switch `plan` and `apply` jobs from `runs-on: self-hosted` to `runs-on: ubuntu-latest`
- Remove the `Install dependencies` step — `unzip` is pre-installed on `ubuntu-latest`, and the self-hosted runner required a sudo password which blocked the workflow

## Test plan

- [ ] Terraform `plan` job runs successfully on `ubuntu-latest`
- [ ] Terraform `apply` job runs successfully on `ubuntu-latest`

https://claude.ai/code/session_014kYUkhHEn3ohvi56pL3wsf