### PR TITLE
Add nightly wedding DB backup via cron and docker exec

### DIFF
--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -10,6 +10,7 @@ containers:
   - pubgolf-backend
   - pubgolf-frontend
   - wedding-db
+  - wedding-db-backup
   - wedding
   # Infrastructure
   - adguard

--- a/tasks/docker/wedding-db-backup.yml
+++ b/tasks/docker/wedding-db-backup.yml
@@ -1,7 +1,7 @@
 ---
 - name: WEDDING-DB-BACKUP - Create backup directory
   ansible.builtin.file:
-    path: "{{ base_dir }}/wedding-db/backups"
+    path: "{{ base_dir }}/backups"
     state: directory
     mode: "0750"
 
@@ -12,7 +12,7 @@
     content: |
       #!/bin/sh
       set -eu
-      BACKUP_DIR="{{ base_dir }}/wedding-db/backups"
+      BACKUP_DIR="{{ base_dir }}/backups"
       RETENTION_DAYS=14
       SLUG=$(date -u +%Y-%m-%dT%H-%M-%SZ)
       OUT="$BACKUP_DIR/pgdump-$SLUG.dump"

--- a/tasks/docker/wedding-db-backup.yml
+++ b/tasks/docker/wedding-db-backup.yml
@@ -1,0 +1,33 @@
+---
+- name: WEDDING-DB-BACKUP - Create backup directory
+  ansible.builtin.file:
+    path: "{{ base_dir }}/wedding-db/backups"
+    state: directory
+    mode: "0750"
+
+- name: WEDDING-DB-BACKUP - Write backup script
+  ansible.builtin.copy:
+    dest: "{{ base_dir }}/wedding-db/backup.sh"
+    mode: "0755"
+    content: |
+      #!/bin/sh
+      set -eu
+      BACKUP_DIR="{{ base_dir }}/wedding-db/backups"
+      RETENTION_DAYS=14
+      SLUG=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+      OUT="$BACKUP_DIR/pgdump-$SLUG.dump"
+      docker exec wedding-db pg_dump \
+        -U postgres \
+        -Fc \
+        wedding \
+        > "$OUT"
+      echo "[backup] wrote $OUT"
+      find "$BACKUP_DIR" -name "pgdump-*.dump" -mtime +"$RETENTION_DAYS" -delete
+
+- name: WEDDING-DB-BACKUP - Schedule nightly cron job
+  ansible.builtin.cron:
+    name: wedding-db-backup
+    minute: "15"
+    hour: "2"
+    job: "/bin/sh {{ base_dir }}/wedding-db/backup.sh >> /var/log/wedding-backup.log 2>&1"
+    state: present


### PR DESCRIPTION
## Summary

- Adds `tasks/docker/wedding-db-backup.yml` to deploy a nightly backup for the wedding Postgres container
- Creates `{{ base_dir }}/wedding-db/backups/` on the host for dump storage
- Writes a shell script that calls `docker exec wedding-db pg_dump` (no extra tooling needed on the host)
- Registers a host cron job via `ansible.builtin.cron` to run at 02:15 nightly with 14-day retention

## Usage

Import the task in your main playbook after `wedding-db.yml`:

\`\`\`yaml
- import_tasks: tasks/docker/wedding-db-backup.yml
\`\`\`

## Test plan

- [ ] Run playbook, check `crontab -l` shows the job
- [ ] Run `bash {{ base_dir }}/wedding-db/backup.sh` manually and confirm a dump appears in `backups/`
- [ ] Check dump is valid: `docker exec wedding-db pg_restore --list /dev/stdin < backups/pgdump-<slug>.dump | head`
- [ ] After nightly run: `tail /var/log/wedding-backup.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)