### PR TITLE
Add Marginalia deployment

### DIFF
--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -9,6 +9,11 @@ containers:
   - mcpjungle
   # Apps
   - family-hub
+  - marginalia-postgres
+  - marginalia-api
+  - marginalia-worker-metadata
+  - marginalia-worker-import
+  - marginalia-worker-reviews
   - pubgolf-backend
   - pubgolf-frontend
   - wedding-db

--- a/tasks/docker/marginalia-api.yml
+++ b/tasks/docker/marginalia-api.yml
@@ -47,7 +47,6 @@
       secured: false
       healthcheck: true
       healthcheck_path: /healthz
-      homepage: true
       proxied: true
 
 - name: MARGINALIA-API - Append to docker_services

--- a/tasks/docker/marginalia-api.yml
+++ b/tasks/docker/marginalia-api.yml
@@ -1,0 +1,55 @@
+---
+- name: MARGINALIA-API - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+  loop:
+    - "{{ base_dir }}/marginalia/covers"
+
+- name: MARGINALIA-API - Create container
+  community.docker.docker_container:
+    name: marginalia-api
+    image: ghcr.io/bensuskins/marginalia-api:latest
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    ports:
+      - "8085:8080"
+    volumes:
+      - "{{ base_dir }}/marginalia/covers:/var/lib/marginalia/covers"
+    env:
+      DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
+      AUTH_JWT_SECRET: "{{ MARGINALIA_AUTH_JWT_SECRET }}"
+      SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
+      APPLE_BUNDLE_ID: "{{ MARGINALIA_APPLE_BUNDLE_ID }}"
+      GOOGLE_CLIENT_ID: "{{ MARGINALIA_GOOGLE_CLIENT_ID }}"
+      ASK_MODEL: claude-haiku-4-5
+      HARDCOVER_TOKEN: "{{ MARGINALIA_HARDCOVER_TOKEN }}"
+      HARDCOVER_ENABLED: "true"
+
+- name: MARGINALIA-API - Define service entry
+  ansible.builtin.set_fact:
+    marginalia_api_entry:
+      name: marginalia-api
+      description: Marginalia book tracker API
+      icon: bookstack
+      host: "marginalia.{{ domain }}"
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 8085
+      scheme: http
+      secured: false
+      healthcheck: true
+      healthcheck_path: /healthz
+      homepage: true
+      proxied: true
+
+- name: MARGINALIA-API - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [marginalia_api_entry] }}"

--- a/tasks/docker/marginalia-postgres.yml
+++ b/tasks/docker/marginalia-postgres.yml
@@ -1,0 +1,38 @@
+---
+- name: MARGINALIA-POSTGRES - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    owner: "999"
+    group: "999"
+    mode: "0750"
+  loop:
+    - "{{ base_dir }}/marginalia/postgres"
+
+- name: MARGINALIA-POSTGRES - Create container
+  community.docker.docker_container:
+    name: marginalia-postgres
+    image: postgres:16-alpine
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    volumes:
+      - "{{ base_dir }}/marginalia/postgres:/var/lib/postgresql/data"
+    env:
+      POSTGRES_DB: marginalia
+      POSTGRES_USER: marginalia
+      POSTGRES_PASSWORD: "{{ MARGINALIA_POSTGRES_PASSWORD }}"
+
+- name: MARGINALIA-POSTGRES - Define service entry
+  ansible.builtin.set_fact:
+    marginalia_postgres_entry:
+      name: marginalia-postgres
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+
+- name: MARGINALIA-POSTGRES - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [marginalia_postgres_entry] }}"

--- a/tasks/docker/marginalia-postgres.yml
+++ b/tasks/docker/marginalia-postgres.yml
@@ -26,13 +26,3 @@
       POSTGRES_USER: marginalia
       POSTGRES_PASSWORD: "{{ MARGINALIA_POSTGRES_PASSWORD }}"
 
-- name: MARGINALIA-POSTGRES - Define service entry
-  ansible.builtin.set_fact:
-    marginalia_postgres_entry:
-      name: marginalia-postgres
-      ip: "{{ inventory_hostname }}"
-      friendly_name: "{{ friendly_name }}"
-
-- name: MARGINALIA-POSTGRES - Append to docker_services
-  ansible.builtin.set_fact:
-    docker_services: "{{ docker_services + [marginalia_postgres_entry] }}"

--- a/tasks/docker/marginalia-worker-import.yml
+++ b/tasks/docker/marginalia-worker-import.yml
@@ -25,13 +25,3 @@
       DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
       SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
 
-- name: MARGINALIA-WORKER-IMPORT - Define service entry
-  ansible.builtin.set_fact:
-    marginalia_worker_import_entry:
-      name: marginalia-worker-import
-      ip: "{{ inventory_hostname }}"
-      friendly_name: "{{ friendly_name }}"
-
-- name: MARGINALIA-WORKER-IMPORT - Append to docker_services
-  ansible.builtin.set_fact:
-    docker_services: "{{ docker_services + [marginalia_worker_import_entry] }}"

--- a/tasks/docker/marginalia-worker-import.yml
+++ b/tasks/docker/marginalia-worker-import.yml
@@ -1,0 +1,37 @@
+---
+- name: MARGINALIA-WORKER-IMPORT - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+  loop:
+    - "{{ base_dir }}/marginalia/imports"
+
+- name: MARGINALIA-WORKER-IMPORT - Create container
+  community.docker.docker_container:
+    name: marginalia-worker-import
+    image: ghcr.io/bensuskins/marginalia-worker-import:latest
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    volumes:
+      - "{{ base_dir }}/marginalia/imports:/var/lib/marginalia/imports"
+    env:
+      DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
+      SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
+
+- name: MARGINALIA-WORKER-IMPORT - Define service entry
+  ansible.builtin.set_fact:
+    marginalia_worker_import_entry:
+      name: marginalia-worker-import
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+
+- name: MARGINALIA-WORKER-IMPORT - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [marginalia_worker_import_entry] }}"

--- a/tasks/docker/marginalia-worker-metadata.yml
+++ b/tasks/docker/marginalia-worker-metadata.yml
@@ -1,0 +1,24 @@
+---
+- name: MARGINALIA-WORKER-METADATA - Create container
+  community.docker.docker_container:
+    name: marginalia-worker-metadata
+    image: ghcr.io/bensuskins/marginalia-worker-metadata:latest
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    env:
+      DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
+      SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
+
+- name: MARGINALIA-WORKER-METADATA - Define service entry
+  ansible.builtin.set_fact:
+    marginalia_worker_metadata_entry:
+      name: marginalia-worker-metadata
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+
+- name: MARGINALIA-WORKER-METADATA - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [marginalia_worker_metadata_entry] }}"

--- a/tasks/docker/marginalia-worker-metadata.yml
+++ b/tasks/docker/marginalia-worker-metadata.yml
@@ -12,13 +12,3 @@
       DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
       SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
 
-- name: MARGINALIA-WORKER-METADATA - Define service entry
-  ansible.builtin.set_fact:
-    marginalia_worker_metadata_entry:
-      name: marginalia-worker-metadata
-      ip: "{{ inventory_hostname }}"
-      friendly_name: "{{ friendly_name }}"
-
-- name: MARGINALIA-WORKER-METADATA - Append to docker_services
-  ansible.builtin.set_fact:
-    docker_services: "{{ docker_services + [marginalia_worker_metadata_entry] }}"

--- a/tasks/docker/marginalia-worker-reviews.yml
+++ b/tasks/docker/marginalia-worker-reviews.yml
@@ -1,0 +1,26 @@
+---
+- name: MARGINALIA-WORKER-REVIEWS - Create container
+  community.docker.docker_container:
+    name: marginalia-worker-reviews
+    image: ghcr.io/bensuskins/marginalia-worker-reviews:latest
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    env:
+      DATABASE_URL: "postgres://marginalia:{{ MARGINALIA_POSTGRES_PASSWORD }}@marginalia-postgres:5432/marginalia?sslmode=disable"
+      SECRET_ENCRYPTION_KEY: "{{ MARGINALIA_SECRET_ENCRYPTION_KEY }}"
+      HARDCOVER_TOKEN: "{{ MARGINALIA_HARDCOVER_TOKEN }}"
+      HARDCOVER_ENABLED: "true"
+
+- name: MARGINALIA-WORKER-REVIEWS - Define service entry
+  ansible.builtin.set_fact:
+    marginalia_worker_reviews_entry:
+      name: marginalia-worker-reviews
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+
+- name: MARGINALIA-WORKER-REVIEWS - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [marginalia_worker_reviews_entry] }}"

--- a/tasks/docker/marginalia-worker-reviews.yml
+++ b/tasks/docker/marginalia-worker-reviews.yml
@@ -14,13 +14,3 @@
       HARDCOVER_TOKEN: "{{ MARGINALIA_HARDCOVER_TOKEN }}"
       HARDCOVER_ENABLED: "true"
 
-- name: MARGINALIA-WORKER-REVIEWS - Define service entry
-  ansible.builtin.set_fact:
-    marginalia_worker_reviews_entry:
-      name: marginalia-worker-reviews
-      ip: "{{ inventory_hostname }}"
-      friendly_name: "{{ friendly_name }}"
-
-- name: MARGINALIA-WORKER-REVIEWS - Append to docker_services
-  ansible.builtin.set_fact:
-    docker_services: "{{ docker_services + [marginalia_worker_reviews_entry] }}"


### PR DESCRIPTION
Five containers: postgres, api, worker-metadata, worker-import, worker-reviews. API proxied via Traefik at marginalia.suskins.co.uk on port 8085.

Vault vars required:
  MARGINALIA_POSTGRES_PASSWORD
  MARGINALIA_AUTH_JWT_SECRET
  MARGINALIA_SECRET_ENCRYPTION_KEY
  MARGINALIA_APPLE_BUNDLE_ID
  MARGINALIA_GOOGLE_CLIENT_ID
  MARGINALIA_HARDCOVER_TOKEN

First deploy: run migrations after bringing up postgres and api:
  docker exec marginalia-api /bin/marginalia-api migrate