### PR TITLE
Replace MCP Jungle with MetaMCP

### DIFF
--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -6,7 +6,8 @@ special_containers:
 
 containers:
   # MCP
-  - mcpjungle
+  - metamcp-postgres
+  - metamcp
   # Apps
   - family-hub
   # - marginalia-postgres

--- a/tasks/docker/metamcp-postgres.yml
+++ b/tasks/docker/metamcp-postgres.yml
@@ -1,0 +1,25 @@
+---
+- name: METAMCP-POSTGRES - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ base_dir }}/metamcp/postgres"
+    recurse: true
+    state: directory
+    owner: "999"
+    group: "999"
+    mode: "0750"
+
+- name: METAMCP-POSTGRES - Create container
+  community.docker.docker_container:
+    name: metamcp-postgres
+    image: postgres:16-alpine
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    volumes:
+      - "{{ base_dir }}/metamcp/postgres:/var/lib/postgresql/data"
+    env:
+      POSTGRES_DB: metamcp
+      POSTGRES_USER: metamcp
+      POSTGRES_PASSWORD: "{{ METAMCP_POSTGRES_PASSWORD }}"

--- a/tasks/docker/metamcp.yml
+++ b/tasks/docker/metamcp.yml
@@ -1,0 +1,46 @@
+---
+- name: METAMCP - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ base_dir }}/metamcp"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+
+- name: METAMCP - Create container
+  community.docker.docker_container:
+    name: metamcp
+    image: ghcr.io/metatool-ai/metamcp:latest
+    restart_policy: always
+    state: started
+    pull: true
+    networks:
+      - name: homelab
+    ports:
+      - "12008:12008"
+    env:
+      POSTGRES_HOST: metamcp-postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: metamcp
+      POSTGRES_USER: metamcp
+      POSTGRES_PASSWORD: "{{ METAMCP_POSTGRES_PASSWORD }}"
+      AUTH_SECRET: "{{ METAMCP_AUTH_SECRET }}"
+
+- name: METAMCP - Define service entry
+  ansible.builtin.set_fact:
+    metamcp_entry:
+      name: metamcp
+      description: MCP gateway
+      host: "mcp.{{ domain }}"
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 12008
+      scheme: http
+      secured: true
+      homepage: true
+      proxied: true
+
+- name: METAMCP - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [metamcp_entry] }}"


### PR DESCRIPTION
## Summary

- Replaces MCP Jungle with [MetaMCP](https://github.com/metatool-ai/metamcp) as the MCP gateway
- MetaMCP supports streamable HTTP transport (MCP SDK v1.x), fixing the incompatibility with `mcp-arr` which caused the 4xx initialize error
- Adds a dedicated PostgreSQL container (`metamcp-postgres`) as required by MetaMCP
- MetaMCP retains the same `mcp.suskins.co.uk` host and Traefik/Authelia config

## Changes

- `tasks/docker/metamcp-postgres.yml` — new PostgreSQL dependency
- `tasks/docker/metamcp.yml` — MetaMCP container replacing mcpjungle
- `group_vars/docker.yml` — swap `mcpjungle` for `metamcp-postgres` + `metamcp`

## Before deploying

Two new secrets must be added to `vault.yml`:

```
METAMCP_POSTGRES_PASSWORD: <generate a strong password>
METAMCP_AUTH_SECRET: <generate a strong secret>
```

```bash
ansible-vault edit vault.yml
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYMrxjSirEUCTUsaPipiHd)_