### PR TITLE
fix(authelia): persist sessions via Redis

### DIFF
--- a/config/authelia/configuration.yml.j2
+++ b/config/authelia/configuration.yml.j2
@@ -60,6 +60,9 @@ access_control:
       policy: two_factor
 
 session:
+  redis:
+    host: redis
+    port: 6379
   cookies:
     - domain: "{{ domain }}"
       authelia_url: "https://authelia.{{ domain }}"

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -6,4 +6,5 @@ special_containers:
   - traefik
 
 containers:
+  - redis
   - authelia

--- a/tasks/docker/redis.yml
+++ b/tasks/docker/redis.yml
@@ -1,0 +1,24 @@
+---
+- name: REDIS - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    mode: "0755"
+  loop:
+    - "{{ base_dir }}/redis/data"
+
+- name: REDIS - Create container
+  community.docker.docker_container:
+    name: redis
+    image: redis:7.4-alpine
+    restart_policy: always
+    state: started
+    pull: true
+    command: redis-server --appendonly yes
+    networks:
+      - name: homelab
+    volumes:
+      - "{{ base_dir }}/redis/data:/data"
+    env:
+      TZ: "{{ timezone }}"


### PR DESCRIPTION
Authelia used in-memory session storage, so every host reboot wiped all sessions. update.yml reboots the host on any container change and runs on push to main, causing frequent forced re-logins.

Add a persistent Redis container (appendonly) on the development host and point Authelia's session provider at it so sessions survive reboots.