### PR TITLE
feat(hermes): add Hermes Agent VM and consolidate MCP servers

### DIFF
--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -5,8 +5,6 @@ special_containers:
   - homepage
 
 containers:
-  # MCP
-  - mcpjungle
   # Apps
   - family-hub
   # - marginalia-postgres

--- a/group_vars/hermes.yml
+++ b/group_vars/hermes.yml
@@ -1,0 +1,13 @@
+---
+base_dir: /home/hermes/server-hermes
+
+special_containers: []
+
+containers:
+  # Agent
+  - hermes-agent
+  - hermes-agent-dashboard
+  # MCP
+  - mcpjungle
+  - sonarr-mcp
+  - radarr-mcp

--- a/group_vars/mediaserver.yml
+++ b/group_vars/mediaserver.yml
@@ -3,9 +3,6 @@ base_dir: /home/mediaserver/server-mediaserver
 mount_nas: true
 
 containers:
-  # MCP
-  - sonarr-mcp
-  - radarr-mcp
   # Streaming
   - plex
   # Media management

--- a/inventory
+++ b/inventory
@@ -32,3 +32,9 @@ ansible_user=monitor
 
 [bumblebee:vars]
 ansible_user=bumblebee
+
+[hermes]
+192.168.0.107 friendly_name="Hermes"
+
+[hermes:vars]
+ansible_user=hermes

--- a/tasks/docker/hermes-agent-dashboard.yml
+++ b/tasks/docker/hermes-agent-dashboard.yml
@@ -1,0 +1,35 @@
+---
+# Shares the /opt/data directory with the hermes-agent gateway container.
+- name: HERMES-AGENT-DASHBOARD - Create dashboard container
+  community.docker.docker_container:
+    name: hermes-agent-dashboard
+    image: nousresearch/hermes-agent:latest
+    restart_policy: always
+    state: started
+    pull: true
+    network_mode: host
+    command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+    env:
+      HERMES_UID: "{{ puid | string }}"
+      HERMES_GID: "{{ pgid | string }}"
+    volumes:
+      - "{{ base_dir }}/hermes-agent:/opt/data"
+
+- name: HERMES-AGENT-DASHBOARD - Define service entry
+  ansible.builtin.set_fact:
+    hermes_agent_entry:
+      name: hermes-agent
+      description: Self-improving AI agent
+      host: "hermes.{{ domain }}"
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 9119
+      scheme: http
+      secured: true
+      healthcheck: true
+      homepage: true
+      proxied: true
+
+- name: HERMES-AGENT-DASHBOARD - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [hermes_agent_entry] }}"

--- a/tasks/docker/hermes-agent.yml
+++ b/tasks/docker/hermes-agent.yml
@@ -1,0 +1,24 @@
+---
+- name: HERMES-AGENT - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ base_dir }}/hermes-agent"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+
+- name: HERMES-AGENT - Create gateway container
+  community.docker.docker_container:
+    name: hermes-agent
+    image: nousresearch/hermes-agent:latest
+    restart_policy: always
+    state: started
+    pull: true
+    network_mode: host
+    command: ["gateway", "run"]
+    env:
+      HERMES_UID: "{{ puid | string }}"
+      HERMES_GID: "{{ pgid | string }}"
+    volumes:
+      - "{{ base_dir }}/hermes-agent:/opt/data"

--- a/tasks/docker/radarr-mcp.yml
+++ b/tasks/docker/radarr-mcp.yml
@@ -11,7 +11,7 @@
     ports:
       - "4200:4200"
     env:
-      RADARR_URL: "http://{{ inventory_hostname }}:7878"
+      RADARR_URL: "http://{{ mediaserver_ip }}:7878"
       RADARR_API_KEY: "{{ RADARR_API_KEY }}"
       RADARR_MCP_HOST: "0.0.0.0"
       RADARR_MCP_PORT: "4200"

--- a/tasks/docker/sonarr-mcp.yml
+++ b/tasks/docker/sonarr-mcp.yml
@@ -11,7 +11,7 @@
     ports:
       - "9171:9171"
     env:
-      SONARR_URL: "http://{{ inventory_hostname }}:8989"
+      SONARR_URL: "http://{{ mediaserver_ip }}:8989"
       SONARR_API_KEY: "{{ SONARR_API_KEY }}"
       SONARR_MCP_HOST: "0.0.0.0"
       SONARR_MCP_PORT: "9171"


### PR DESCRIPTION
## Summary

Adds a new `hermes` VM (`192.168.0.107`) running the [Nous Research Hermes Agent](https://github.com/NousResearch/hermes-agent), and relocates **all** MCP servers onto it for consolidation.

## What's included

**New Hermes VM**
- New inventory group `hermes` (`192.168.0.107`, `ansible_user=hermes`) and `group_vars/hermes.yml`.
- `tasks/docker/hermes-agent.yml` — the **gateway** container (`gateway run`).
- `tasks/docker/hermes-agent-dashboard.yml` — the **dashboard** container (`dashboard --host 0.0.0.0 --no-open`, port `9119`), exposed at `hermes.suskins.co.uk` via Traefik, secured behind Authelia, shown on Homepage, with a Gatus healthcheck.
- Both containers use `network_mode: host` and share `{{ base_dir }}/hermes-agent:/opt/data` (all Hermes state — config, keys, sessions, skills, memories — lives here), matching upstream's supported design. `HERMES_UID`/`HERMES_GID` set to `puid`/`pgid` (1000).

**MCP server consolidation (moved onto hermes)**
- `mcpjungle` moved off the `docker` host.
- `sonarr-mcp` and `radarr-mcp` moved off the `mediaserver` host.
- `sonarr-mcp`/`radarr-mcp` backend URLs changed from `{{ inventory_hostname }}` → `{{ mediaserver_ip }}`, since the containers no longer run on the same host as Sonarr/Radarr (which stay on the mediaserver).

## Notes / why some things were done a certain way

- **Two task files for one app:** `update.yml` reaps any running container whose name isn't literally in a host's `containers` list, so the gateway and dashboard are split into separate files (`hermes-agent`, `hermes-agent-dashboard`) rather than two containers in one file.
- **No firewall on hermes:** matches the `docker`/`mediaserver` hosts (firewall there is off). Enabling UFW would block the MCP ports and Traefik → `9119`.
- **No Terraform DNS change:** `mcp.suskins.co.uk` and the other service subdomains have no individual records in `terraform/` (they resolve via the existing wildcard), so `hermes.suskins.co.uk` needs none either.
- **Renovate:** the new `nousresearch/hermes-agent` image is auto-tracked via the existing `tasks/docker/*.yml` manager pattern.
- **Gateway API server** (port 8642) left disabled per the chosen config — can be enabled later via `API_SERVER_HOST`/`API_SERVER_KEY`.

## Deploy steps (manual, after merge)

```bash
# Provision the VM first (base packages, Docker, homelab network)
ansible-playbook plays/setup.yml -K --ask-vault-pass --limit hermes
# Deploy containers + regenerate Homepage/Traefik/Gatus/Prometheus
ansible-playbook plays/update.yml -K --ask-vault-pass --limit hermes
```

## ⚠️ Things to be aware of

- The VM at `192.168.0.107` must exist with an `hermes` user and the homelab SSH key authorized before running `setup.yml`.
- **mcpjungle registrations are runtime state** stored in its data volume. Moving hosts starts with a fresh volume, so any MCP servers previously registered in mcpjungle will need to be re-registered.
- Hermes Agent's **LLM provider/model is configured via the dashboard** after first start; no API key is baked into the playbook.

https://claude.ai/code/session_01PGEwS4srWnnLj3gzvbqnTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGEwS4srWnnLj3gzvbqnTJ)_