### PR TITLE
Expand VM module options + document cloud-init template

### DIFF
--- a/config/readme/ARCHITECTURE.md.j2
+++ b/config/readme/ARCHITECTURE.md.j2
@@ -37,6 +37,22 @@ flowchart LR
 | `plays/update.yml` | Full update cycle (apt, containers, Traefik/Gatus/Homepage); runs on push to `main` |
 | `plays/clean.yml` | apt cache, journal logs, `docker prune` |
 
+## Proxmox VMs
+
+Hosts themselves are provisioned with Terraform (`terraform/proxmox/`,
+`bpg/proxmox`) and made Ansible-ready by cloud-init:
+
+- **Golden template** — VM ID `9000` on `local-zfs`, built once from the
+  **Debian 13 "trixie"** generic cloud image with **`qemu-guest-agent`** baked in
+  (so the provider can read each clone's IP at create time).
+- **`./modules/vm`** clones the template, injects the login user, SSH key and IP
+  via cloud-init, and exposes knobs for CPU, memory, disk, network, boot order
+  (`startup`), and protection.
+- **Hand-off to Ansible** — cloud-init grants the user passwordless sudo, so a new
+  VM is reachable for `plays/setup.yml` (base packages + Docker) with no manual prep.
+
+See the [README](README.md#cloud-init-template) for the one-time template build.
+
 ## Service Definition Pattern
 
 Every container in `tasks/docker/*.yml` follows the same pattern:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,22 @@ flowchart LR
 | `plays/update.yml` | Full update cycle (apt, containers, Traefik/Gatus/Homepage); runs on push to `main` |
 | `plays/clean.yml` | apt cache, journal logs, `docker prune` |
 
+## Proxmox VMs
+
+Hosts themselves are provisioned with Terraform (`terraform/proxmox/`,
+`bpg/proxmox`) and made Ansible-ready by cloud-init:
+
+- **Golden template** — VM ID `9000` on `local-zfs`, built once from the
+  **Debian 13 "trixie"** generic cloud image with **`qemu-guest-agent`** baked in
+  (so the provider can read each clone's IP at create time).
+- **`./modules/vm`** clones the template, injects the login user, SSH key and IP
+  via cloud-init, and exposes knobs for CPU, memory, disk, network, boot order
+  (`startup`), and protection.
+- **Hand-off to Ansible** — cloud-init grants the user passwordless sudo, so a new
+  VM is reachable for `plays/setup.yml` (base packages + Docker) with no manual prep.
+
+See the [README](README.md#cloud-init-template) for the one-time template build.
+
 ## Service Definition Pattern
 
 Every container in `tasks/docker/*.yml` follows the same pattern:

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,8 +115,38 @@ applies a static IP via cloud-init. New VMs are added to the Ansible `inventory`
 - A Proxmox API token (`terraform@pve!<tokenid>=<secret>`) for a user/role with VM
   lifecycle privileges (`VM.Allocate`, `VM.Clone`, `VM.Config.*`, `VM.PowerMgmt`,
   `Datastore.AllocateSpace`, `Datastore.Audit`).
-- A cloud-init-ready VM template to clone from.
+- The cloud-init template described below.
 - GitHub secrets `PROXMOX_API_TOKEN` and `PROXMOX_ENDPOINT` (R2 secrets already exist).
+
+### Cloud-init template
+
+`terraform/proxmox/modules/vm` clones every VM from a single golden template
+(`clone_template_id`, VM ID **9000** on `local-zfs`):
+
+| Property | Value |
+|----------|-------|
+| Base image | **Debian 13 "trixie"** generic cloud image (`debian-13-genericcloud-amd64.qcow2`, tracks the latest point release, e.g. 13.5) |
+| Guest agent | **`qemu-guest-agent`** baked into the image with `virt-customize` |
+| Disk | ~3 GiB native; clones resize up (default 64 GiB) and cloud-init `growpart` expands the root filesystem on first boot |
+| Cloud-init | user, SSH key and IP are injected **per clone** by Terraform — the template's cloud-init is left blank so it stays reusable |
+
+The guest agent is baked in (not installed later by Ansible) so the bpg provider
+can read each clone's IP at create time — important for DHCP VMs, where the
+address isn't known in advance.
+
+Build it once on the Proxmox node:
+
+```bash
+cd /var/lib/vz/template
+wget https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2
+virt-customize -a debian-13-genericcloud-amd64.qcow2 --install qemu-guest-agent   # needs libguestfs-tools
+qm create 9000 --name debian-13-cloudinit --memory 2048 --cores 2 --net0 virtio,bridge=vmbr0
+qm importdisk 9000 debian-13-genericcloud-amd64.qcow2 local-zfs
+qm set 9000 --scsihw virtio-scsi-pci --scsi0 local-zfs:vm-9000-disk-0
+qm set 9000 --ide2 local-zfs:cloudinit
+qm set 9000 --boot c --bootdisk scsi0 --serial0 socket --vga serial0 --agent enabled=1
+qm template 9000
+```
 
 ## Architecture
 

--- a/terraform/proxmox/modules/vm/main.tf
+++ b/terraform/proxmox/modules/vm/main.tf
@@ -7,36 +7,69 @@ terraform {
 }
 
 resource "proxmox_virtual_environment_vm" "this" {
-  name      = var.name
-  vm_id     = var.vm_id
-  node_name = var.node_name
-  tags      = var.tags
+  name        = var.name
+  description = var.description
+  vm_id       = var.vm_id
+  node_name   = var.node_name
+  tags        = var.tags
+  pool_id     = var.pool_id
+
+  on_boot       = var.on_boot
+  started       = var.started
+  protection    = var.protection
+  bios          = var.bios
+  machine       = var.machine
+  tablet_device = var.tablet_device
 
   clone {
     vm_id = var.clone_template_id
   }
 
   agent {
-    enabled = true
+    enabled = var.agent_enabled
+  }
+
+  dynamic "startup" {
+    for_each = var.startup_order == null ? [] : [1]
+    content {
+      order      = var.startup_order
+      up_delay   = var.startup_up_delay
+      down_delay = var.startup_down_delay
+    }
   }
 
   cpu {
-    cores = var.cores
-    type  = "host"
+    cores   = var.cores
+    sockets = var.cpu_sockets
+    type    = var.cpu_type
+    numa    = var.cpu_numa
+    flags   = var.cpu_flags
   }
 
   memory {
     dedicated = var.memory
+    floating  = var.memory_floating
   }
 
   disk {
     datastore_id = var.datastore_id
     interface    = "scsi0"
     size         = var.disk_size
+    ssd          = var.disk_ssd
+    discard      = var.disk_discard
+    iothread     = var.disk_iothread
+    cache        = var.disk_cache
+    backup       = var.disk_backup
+    replicate    = var.disk_replicate
   }
 
   network_device {
-    bridge = var.bridge
+    bridge      = var.bridge
+    model       = var.network_model
+    vlan_id     = var.vlan_id
+    mac_address = var.network_mac_address
+    firewall    = var.network_firewall
+    rate_limit  = var.network_rate_limit
   }
 
   initialization {

--- a/terraform/proxmox/modules/vm/variables.tf
+++ b/terraform/proxmox/modules/vm/variables.tf
@@ -76,3 +76,185 @@ variable "tags" {
   type        = list(string)
   default     = ["terraform"]
 }
+
+# --- Identity & lifecycle ---
+
+variable "description" {
+  description = "Free-text description shown in the Proxmox UI"
+  type        = string
+  default     = null
+}
+
+variable "pool_id" {
+  description = "Resource pool to place the VM in (e.g. for pool-targeted backup jobs)"
+  type        = string
+  default     = null
+}
+
+variable "protection" {
+  description = "Protect the VM from removal/disk deletion"
+  type        = bool
+  default     = false
+}
+
+variable "on_boot" {
+  description = "Start the VM automatically when the node boots"
+  type        = bool
+  default     = true
+}
+
+variable "started" {
+  description = "Whether the VM should be running"
+  type        = bool
+  default     = true
+}
+
+variable "agent_enabled" {
+  description = "Wait for the QEMU guest agent. Requires qemu-guest-agent in the template (it is baked into ours)."
+  type        = bool
+  default     = true
+}
+
+# --- Boot ordering ---
+
+variable "startup_order" {
+  description = "Boot/shutdown order. When null, no startup config is set."
+  type        = number
+  default     = null
+}
+
+variable "startup_up_delay" {
+  description = "Seconds to wait after this VM starts before starting the next (requires startup_order)"
+  type        = number
+  default     = null
+}
+
+variable "startup_down_delay" {
+  description = "Seconds to wait after this VM stops before stopping the next (requires startup_order)"
+  type        = number
+  default     = null
+}
+
+# --- Firmware / chipset ---
+
+variable "bios" {
+  description = "BIOS implementation: seabios or ovmf"
+  type        = string
+  default     = "seabios"
+}
+
+variable "machine" {
+  description = "Machine type, e.g. pc or q35"
+  type        = string
+  default     = "pc"
+}
+
+variable "tablet_device" {
+  description = "Enable the USB tablet pointer device"
+  type        = bool
+  default     = true
+}
+
+# --- CPU ---
+
+variable "cpu_sockets" {
+  description = "Number of CPU sockets"
+  type        = number
+  default     = 1
+}
+
+variable "cpu_type" {
+  description = "Emulated CPU type (host gives best performance on a homogeneous cluster)"
+  type        = string
+  default     = "host"
+}
+
+variable "cpu_numa" {
+  description = "Enable NUMA"
+  type        = bool
+  default     = false
+}
+
+variable "cpu_flags" {
+  description = "CPU flags, e.g. [\"+aes\"]"
+  type        = list(string)
+  default     = []
+}
+
+# --- Memory ---
+
+variable "memory_floating" {
+  description = "Minimum memory in MiB for ballooning. 0 disables ballooning (fixed memory). Set equal to memory to enable."
+  type        = number
+  default     = 0
+}
+
+# --- Disk ---
+
+variable "disk_ssd" {
+  description = "Present the disk as an SSD to the guest"
+  type        = bool
+  default     = false
+}
+
+variable "disk_discard" {
+  description = "TRIM/discard handling: on or ignore"
+  type        = string
+  default     = "ignore"
+}
+
+variable "disk_iothread" {
+  description = "Use a dedicated iothread for the disk"
+  type        = bool
+  default     = false
+}
+
+variable "disk_cache" {
+  description = "Disk cache mode: none, directsync, writethrough, writeback, unsafe"
+  type        = string
+  default     = "none"
+}
+
+variable "disk_backup" {
+  description = "Include this disk when vzdump backup jobs run"
+  type        = bool
+  default     = true
+}
+
+variable "disk_replicate" {
+  description = "Include this disk in storage replication jobs"
+  type        = bool
+  default     = true
+}
+
+# --- Network ---
+
+variable "network_model" {
+  description = "NIC model: virtio, e1000, e1000e, vmxnet3, rtl8139"
+  type        = string
+  default     = "virtio"
+}
+
+variable "vlan_id" {
+  description = "VLAN tag for the primary NIC (null = untagged)"
+  type        = number
+  default     = null
+}
+
+variable "network_mac_address" {
+  description = "Static MAC for the primary NIC (null = auto). Set this to pin a DHCP reservation."
+  type        = string
+  default     = null
+}
+
+variable "network_firewall" {
+  description = "Enable the Proxmox firewall on the primary NIC"
+  type        = bool
+  default     = false
+}
+
+variable "network_rate_limit" {
+  description = "NIC rate limit in MB/s (null = unlimited)"
+  type        = number
+  default     = null
+}

--- a/terraform/proxmox/vms.tf
+++ b/terraform/proxmox/vms.tf
@@ -9,18 +9,53 @@
 # module "example_vm" {
 #   source            = "./modules/vm"
 #   name              = "example"
-#   username          = "example"     # Ansible ansible_user; defaults to name
+#   username          = "example"        # Ansible ansible_user; defaults to name
 #   vm_id             = 110
 #   node_name         = var.proxmox_node
-#   clone_template_id = 9000          # VM ID of a prepared cloud-init template
+#   clone_template_id = 9000             # VM ID of the cloud-init template
 #   cores             = 2
 #   memory            = 2048
 #   disk_size         = 64
 #   datastore_id      = "local-zfs"
-#   ip_address        = "192.168.0.110/24"
+#   ip_address        = "192.168.0.110/24" # or "dhcp"
 #   gateway           = "192.168.0.1"
 #   ssh_public_keys   = [file("~/.ssh/homelab.pub")]
 #   tags              = ["terraform"]
+#
+#   # --- Optional knobs (all have sensible defaults; shown with their defaults) ---
+#   # description         = "Web server"
+#   # pool_id             = "production"   # for pool-targeted backup jobs
+#   # protection          = false         # block accidental destroy
+#   # on_boot             = true          # start with the node
+#   # started             = true
+#   # agent_enabled       = true
+#   #
+#   # startup_order       = 1             # boot ordering (set to enable)
+#   # startup_up_delay    = 30            # secs before the next VM starts
+#   # startup_down_delay  = 30
+#   #
+#   # cpu_sockets         = 1
+#   # cpu_type            = "host"
+#   # cpu_numa            = false
+#   # cpu_flags           = []
+#   # memory_floating     = 0             # set = memory to enable ballooning
+#   #
+#   # bios                = "seabios"     # or "ovmf"
+#   # machine             = "pc"          # or "q35"
+#   # tablet_device       = true
+#   #
+#   # disk_ssd            = false
+#   # disk_discard        = "ignore"      # "on" to pass TRIM to local-zfs
+#   # disk_iothread       = false
+#   # disk_cache          = "none"
+#   # disk_backup         = true          # include in vzdump backups
+#   # disk_replicate      = true
+#   #
+#   # network_model       = "virtio"
+#   # vlan_id             = null
+#   # network_mac_address = null          # pin for a DHCP reservation
+#   # network_firewall    = false
+#   # network_rate_limit  = null          # MB/s
 # }
 
  module "example_vm" {


### PR DESCRIPTION
## Context

Follow-up to the VM provisioning work: give the `./modules/vm` module full control over VM settings, and document the cloud-init golden template (Debian 13.5 + qemu-guest-agent) in the README/Architecture.

## Module options (all optional, defaults preserve current behaviour)

| Area | New variables |
|------|---------------|
| Lifecycle | `description`, `pool_id`, `protection`, `on_boot`, `started`, `agent_enabled` |
| Boot ordering | `startup_order`, `startup_up_delay`, `startup_down_delay` (rendered via a `dynamic "startup"` block only when `startup_order` is set) |
| Firmware/chipset | `bios`, `machine`, `tablet_device` |
| CPU | `cpu_sockets`, `cpu_type`, `cpu_numa`, `cpu_flags` |
| Memory | `memory_floating` (ballooning) |
| Disk | `disk_ssd`, `disk_discard`, `disk_iothread`, `disk_cache`, `disk_backup`, `disk_replicate` |
| Network | `network_model`, `vlan_id`, `network_mac_address`, `network_firewall`, `network_rate_limit` |

Every default equals the provider's default (or the previously hardcoded value, e.g. `cpu_type = "host"`, `agent_enabled = true`), so a `plan` against existing VMs should be a no-op.

### Backups

bpg has **no resource for scheduled vzdump jobs** — those live in Proxmox (Datacenter → Backup). So this only exposes the per-disk `disk_backup`/`disk_replicate` include flags. The `pool_id` var is here so you can drop VMs into a pool and point a single pool-targeted backup job at them, but the job itself is configured in PVE.

## Docs

- **README** — new "Cloud-init template" section: Debian 13 "trixie" generic cloud image (tracks latest point release, e.g. 13.5), `qemu-guest-agent` baked in via `virt-customize`, template VM `9000` on `local-zfs`, and the one-time build runbook (now using `local-zfs`).
- **ARCHITECTURE** — new "Proxmox VMs" section (edited the `config/readme/ARCHITECTURE.md.j2` source template and mirrored into the generated `docs/ARCHITECTURE.md`).
- `vms.tf` example comment expanded to show every optional knob with its default.

## Notes

- The active `example_vm` (vm_id 500) test block is left untouched so it isn't destroyed.
- Intentionally omitted for now (easy to add): `vga`, `kvm_arguments`, extra disks, PCI passthrough.

## Verification

- `terraform plan` in `terraform/proxmox`: no changes for existing VMs; new knobs available.
- Set `startup_order = 1` / `disk_ssd = true` etc. on a VM and confirm they appear in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)