### PR TITLE
Plan and comment Terraform changes on PRs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,7 +5,14 @@ on:
     branches: [main]
     paths:
       - 'terraform/**'
+  pull_request:
+    paths:
+      - 'terraform/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -15,7 +22,110 @@ env:
   TF_VAR_proxmox_endpoint: ${{ secrets.PROXMOX_ENDPOINT }}
 
 jobs:
+  plan-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: [cloudflare, proxmox]
+    defaults:
+      run:
+        working-directory: terraform/${{ matrix.dir }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        continue-on-error: true
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_STDERR: ${{ steps.plan.outputs.stderr }}
+        with:
+          script: |
+            const dir = '${{ matrix.dir }}';
+            const marker = `<!-- terraform-plan:${dir} -->`;
+
+            const stdout = process.env.PLAN_STDOUT || '';
+            const stderr = process.env.PLAN_STDERR || '';
+            let output = (stdout + (stderr ? `\n${stderr}` : '')).trim() || 'No output.';
+
+            const limit = 60000;
+            if (output.length > limit) {
+              output = output.slice(0, limit) + '\n... (truncated — see the job log for the full plan)';
+            }
+
+            const body = [
+              marker,
+              `### Terraform Plan — \`${dir}\``,
+              '',
+              `| Step | Result |`,
+              `| --- | --- |`,
+              `| Format | \`${{ steps.fmt.outcome }}\` |`,
+              `| Validate | \`${{ steps.validate.outcome }}\` |`,
+              `| Plan | \`${{ steps.plan.outcome }}\` |`,
+              '',
+              '<details><summary>Show plan</summary>',
+              '',
+              '```terraform',
+              output,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if format, validate or plan failed
+        if: steps.fmt.outcome == 'failure' || steps.validate.outcome == 'failure' || steps.plan.outcome == 'failure'
+        run: |
+          echo "fmt=${{ steps.fmt.outcome }} validate=${{ steps.validate.outcome }} plan=${{ steps.plan.outcome }}"
+          exit 1
+
   plan:
+    if: github.event_name != 'pull_request'
     runs-on: self-hosted
     strategy:
       fail-fast: false
@@ -51,6 +161,7 @@ jobs:
           path: terraform/${{ matrix.dir }}/tfplan
 
   apply:
+    if: github.event_name != 'pull_request'
     runs-on: self-hosted
     needs: plan
     environment: production


### PR DESCRIPTION
## What

Adds CI feedback for Terraform PRs: when a PR touches `terraform/**`, run `terraform plan` for both roots and post the result as a comment on the PR.

### New `plan-pr` job (runs only on `pull_request`)
- Matrix over `cloudflare` and `proxmox`.
- Runs `terraform fmt -check -recursive`, `validate`, and `plan` (each `continue-on-error` so the comment is always posted).
- Upserts a **sticky comment per root** (keyed by a hidden `<!-- terraform-plan:<dir> -->` marker) via `actions/github-script` — re-running on new commits updates the same comment instead of spamming.
- Fails the check if fmt/validate/plan failed, so the plan result gates the PR.

### Existing jobs
- `plan` and `apply` are gated with `if: github.event_name != 'pull_request'`, so the real apply still only runs on push to `main` (unchanged behaviour).

## Security
Untrusted `terraform plan` output is passed via `env:` and read from `process.env` inside `github-script` — never interpolated into a shell `run:`. The only `${{ }}` interpolations are trusted (`matrix.dir`, `steps.*.outcome`). Uses `pull_request` (not `pull_request_target`), so fork PRs run without secrets.

## Notes
- Runs on the `self-hosted` runner (Proxmox API is LAN-only) and needs the same R2 + Cloudflare + Proxmox secrets the apply job already uses. Same-repo branch PRs get secrets; fork PRs won't be able to plan.
- The path filter means this PR (workflow-only) won't trigger the new job. It takes effect for terraform PRs once merged — e.g. PR #108 will get a plan comment after a re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)