### PR TITLE
Add Home Assistant OS VM as Terraform

### DIFF
--- a/plans/homeassistant-haos-terraform.md
+++ b/plans/homeassistant-haos-terraform.md
@@ -1,0 +1,109 @@
+# Recreate Home Assistant (HAOS) VM in Terraform
+
+## Goal
+Define the Home Assistant OS VM as code in `terraform/proxmox/`, build a **fresh**
+VM (`vm_id 205`, `192.168.0.205`) alongside the existing running `vm_id 101`, then
+cut over by restoring an HA backup. The old `101` stays untouched until verified.
+
+## Why this needs its own module (not `./modules/vm`)
+`./modules/vm` is hardwired for the Debian flow: it `clone`s the cloud-init template
+(`clone_template_id` is now required) and injects a user + SSH key via the
+`initialization` (cloud-init) block. HAOS is an **appliance image**, so:
+- It is **imported** from a qcow2, never cloned.
+- It has **no SSH user** and ignores Proxmox cloud-init networking.
+- It needs an explicit **EFI disk** and **USB passthrough** the shared module doesn't model.
+- Ansible is **not involved at all** — there is no host to configure.
+
+So we add a dedicated `terraform/proxmox/modules/haos/` module + a `homeassistant.tf`
+root file, mirroring the per-VM-file convention.
+
+## Source-of-truth hardware (from VM 101)
+| Setting | Value |
+|---|---|
+| BIOS | OVMF (UEFI) + 4M EFI disk, pre-enrolled keys OFF |
+| Machine | q35 |
+| SCSI controller | VirtIO SCSI |
+| Disk | scsi0, 32G, `ssd=1`, `discard=on`, `cache=writethrough`, on `local-zfs` |
+| CPU | 2 cores / 1 socket, `host` |
+| Memory | 2048 MiB (fixed, no ballooning) |
+| NIC | virtio on vmbr0 |
+| USB | Zigbee/Z-Wave coordinator — pin **by vendor:product ID** |
+
+## Decisions locked in
+- **Image delivery: manual prep.** bpg `download_file` decompresses gz/lzo/zst/bz2
+  but **not xz**; HAOS only ships `.qcow2.xz`. So we download + `unxz` once and
+  upload to Proxmox storage; Terraform imports that qcow2 via `disk.import_from`.
+- **USB: by vendor:product ID** (survives re-plugging) — `1a86:55d4`, the CH9102
+  serial chip in the Sonoff ZBDongle-E (Zigbee 3.0 Dongle Plus V2).
+- **Identity: vm_id 205, 192.168.0.205.** MAC is **auto-assigned** (HAOS ignores
+  cloud-init static IPs, unlike the Debian VMs); read the `homeassistant_mac`
+  output after apply and add a DHCP reservation for it → `.205`.
+- **Values are inlined** in `homeassistant.tf` (matching the per-VM file
+  convention), not routed through root variables. Only the image path is a
+  placeholder to fill in.
+
+## Prerequisites (manual, before `terraform apply`)
+1. **HA backup**: Settings → System → Backups → create + download a full backup.
+2. **Prep the HAOS image on the `pve` node** (pick the current HAOS release version):
+   ```bash
+   cd /var/lib/vz/template/iso
+   wget https://github.com/home-assistant/operating-system/releases/download/<VER>/haos_ova-<VER>.qcow2.xz
+   unxz haos_ova-<VER>.qcow2.xz
+   ```
+   Confirm the resulting file is importable (PVE "import" content / a path
+   `import_from` can read). Record the exact file ID/path → `haos_image_file_id`.
+   This is the only value still to fill into `homeassistant.tf` (`haos_image_file_id`).
+3. USB ID is already known and inlined: `1a86:55d4` (Sonoff ZBDongle-E).
+4. MAC is auto-assigned by Proxmox — no need to pick one. After the first apply,
+   read the `homeassistant_mac` output and add a DHCP reservation for it → `.205`.
+
+## Files to add
+### `terraform/proxmox/modules/haos/main.tf`
+`proxmox_virtual_environment_vm "this"` with:
+- `bios = "ovmf"`, `machine = "q35"`, `scsi_hardware = "virtio-scsi-pci"`
+- `agent { enabled = true }` (HAOS ships the guest agent → populates ipv4 output)
+- `cpu { cores=var.cores, type="host" }`, `memory { dedicated=var.memory }`
+- `efi_disk { datastore_id=var.datastore_id, type="4m", file_format="raw", pre_enrolled_keys=false }`
+- `disk { datastore_id, interface="scsi0", import_from=var.haos_image_file_id, size=var.disk_size, ssd=true, discard="on", cache="writethrough" }`
+  - **Gotcha**: provider defaults qcow2 import size to 8G if unset — set `size=32` explicitly.
+- `network_device { bridge="vmbr0", model="virtio", mac_address=var.mac_address }`
+- `usb { host=var.usb_device_id, usb3=false }`
+- `lifecycle { ignore_changes = [disk[0].import_from] }` so a later image version
+  bump doesn't try to re-import over the live disk.
+
+### `terraform/proxmox/modules/haos/{variables,outputs}.tf`
+Vars: name, vm_id, node_name, cores(=2), memory(=2048), disk_size(=32),
+datastore_id(="local-zfs"), bridge(="vmbr0"), mac_address, usb_device_id,
+haos_image_file_id, description, tags, on_boot, started, startup_order.
+Output: `ipv4_addresses`.
+
+### `terraform/proxmox/homeassistant.tf`
+`module "homeassistant"` wiring the above (vm_id 205, the pinned MAC, the two
+prerequisite IDs) + `output "homeassistant_ipv4"`.
+
+### `terraform/proxmox/homeassistant.tf` (values inlined)
+USB ID and disk/cpu/mem are literals; MAC omitted (auto). `haos_image_file_id`
+is the one placeholder to set after image prep. No root variables added —
+matches the inline convention of the other per-VM files.
+
+## Cutover runbook (after apply)
+1. `terraform apply` → VM 205 boots HAOS (dongle **not** yet attached if 101 holds it —
+   USB can only bind to one running VM at a time).
+2. Browse to `http://192.168.0.205:8123` → onboarding → **Restore from backup** → upload.
+3. Short maintenance window: **stop 101** (frees the dongle) → start/confirm 205 grabs it →
+   verify Zigbee/Z-Wave devices report in.
+4. Verify automations/integrations, then decommission 101 manually (101 is **not**
+   in TF state, so deleting it is a Proxmox action, not `terraform destroy`).
+5. Read `terraform output homeassistant_mac` and add a DHCP reservation for it → `.205`.
+
+## Follow-ups / watch-outs
+- **`home-assistant` MCP**: its configured HA URL likely points at 101's current IP.
+  After cutover, update the MCP endpoint to `.205`. The long-lived token is restored
+  with the backup, so it should keep working.
+- HA is intentionally **absent from the Ansible inventory** and the `docker_services`
+  discovery — no change there. (Optionally add a `static_services` Homepage tile later;
+  out of scope here.)
+- Known HAOS-on-Proxmox boot snag: if it drops to UEFI shell, the `pre_enrolled_keys=false`
+  EFI disk is the fix we've already specified.
+## Open input still required from you
+- `haos_image_file_id` in `homeassistant.tf` (after image prep, step 2)

--- a/terraform/proxmox/homeassistant.tf
+++ b/terraform/proxmox/homeassistant.tf
@@ -1,0 +1,34 @@
+module "homeassistant" {
+  source       = "./modules/haos"
+  name         = "homeassistant"
+  vm_id        = 205
+  node_name    = var.proxmox_node
+  cores        = 2
+  memory       = 2048
+  disk_size    = 32
+  datastore_id = "local-zfs"
+
+  # MAC is auto-assigned (HAOS ignores cloud-init static IPs, unlike the Debian
+  # VMs). After the first apply, read homeassistant_mac and add a DHCP
+  # reservation pointing it at 192.168.0.205.
+
+  # Sonoff ZBDongle-E (Zigbee 3.0 Dongle Plus V2). 1a86:55d4 is its CH9102
+  # USB-serial chip; don't pin a second CH340/CH9102 device the same way.
+  usb_device_id = "1a86:55d4"
+
+  # TODO: set after uploading the unxz'd HAOS qcow2 to the node, e.g.
+  # "local:iso/haos_ova-16.0.qcow2". bpg cannot decompress the .xz HAOS ships.
+  haos_image_file_id = "local:iso/haos_ova.qcow2"
+
+  description = "Home Assistant OS"
+}
+
+output "homeassistant_ipv4" {
+  description = "IPv4 addresses reported by the Home Assistant VM guest agent"
+  value       = module.homeassistant.ipv4_addresses
+}
+
+output "homeassistant_mac" {
+  description = "Auto-assigned NIC MAC; add a DHCP reservation for it pointing at 192.168.0.205"
+  value       = module.homeassistant.mac_address
+}

--- a/terraform/proxmox/modules/haos/main.tf
+++ b/terraform/proxmox/modules/haos/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source = "bpg/proxmox"
+    }
+  }
+}
+
+# Home Assistant OS is an appliance image, not a cloud-init Debian clone:
+# the disk is imported from a prepared qcow2, there is no SSH user, and it
+# needs an explicit EFI disk plus USB passthrough for the radio coordinator.
+resource "proxmox_virtual_environment_vm" "this" {
+  name        = var.name
+  description = var.description
+  vm_id       = var.vm_id
+  node_name   = var.node_name
+  tags        = var.tags
+
+  bios          = "ovmf"
+  machine       = "q35"
+  scsi_hardware = "virtio-scsi-pci"
+
+  on_boot = var.on_boot
+  started = var.started
+
+  # HAOS ships the QEMU guest agent, so this populates ipv4_addresses.
+  agent {
+    enabled = true
+  }
+
+  dynamic "startup" {
+    for_each = var.startup_order == null ? [] : [1]
+    content {
+      order = var.startup_order
+    }
+  }
+
+  cpu {
+    cores   = var.cores
+    sockets = 1
+    type    = "host"
+  }
+
+  memory {
+    dedicated = var.memory
+  }
+
+  efi_disk {
+    datastore_id      = var.datastore_id
+    file_format       = "raw"
+    type              = "4m"
+    pre_enrolled_keys = false
+  }
+
+  disk {
+    datastore_id = var.datastore_id
+    interface    = "scsi0"
+    import_from  = var.haos_image_file_id
+    size         = var.disk_size
+    ssd          = true
+    discard      = "on"
+    cache        = "writethrough"
+  }
+
+  network_device {
+    bridge      = var.bridge
+    model       = "virtio"
+    mac_address = var.mac_address
+  }
+
+  usb {
+    host = var.usb_device_id
+    usb3 = false
+  }
+
+  # The image is imported once; a later HAOS version bump must not try to
+  # re-import over the live disk (HAOS updates itself in-place).
+  lifecycle {
+    ignore_changes = [disk[0].import_from]
+  }
+}

--- a/terraform/proxmox/modules/haos/outputs.tf
+++ b/terraform/proxmox/modules/haos/outputs.tf
@@ -1,0 +1,19 @@
+output "vm_id" {
+  description = "Numeric Proxmox VM ID"
+  value       = proxmox_virtual_environment_vm.this.vm_id
+}
+
+output "name" {
+  description = "VM name"
+  value       = proxmox_virtual_environment_vm.this.name
+}
+
+output "ipv4_addresses" {
+  description = "IPv4 addresses reported by the guest agent"
+  value       = proxmox_virtual_environment_vm.this.ipv4_addresses
+}
+
+output "mac_address" {
+  description = "MAC address of the primary NIC (for a DHCP reservation)"
+  value       = proxmox_virtual_environment_vm.this.network_device[0].mac_address
+}

--- a/terraform/proxmox/modules/haos/variables.tf
+++ b/terraform/proxmox/modules/haos/variables.tf
@@ -1,0 +1,91 @@
+variable "name" {
+  description = "VM name (hostname)"
+  type        = string
+  default     = "homeassistant"
+}
+
+variable "vm_id" {
+  description = "Numeric Proxmox VM ID"
+  type        = number
+}
+
+variable "node_name" {
+  description = "Proxmox node the VM is created on"
+  type        = string
+}
+
+variable "haos_image_file_id" {
+  description = "File ID / path of the prepared (decompressed) HAOS qcow2 to import, e.g. local:iso/haos_ova-15.0.qcow2. Must be unxz'd first; bpg cannot decompress .xz."
+  type        = string
+}
+
+variable "usb_device_id" {
+  description = "Radio coordinator USB device pinned by vendor:product, e.g. 10c4:ea60 (from `lsusb` on the node)."
+  type        = string
+}
+
+variable "mac_address" {
+  description = "MAC for the NIC. null lets Proxmox auto-assign one; read the mac_address output and add a matching DHCP reservation for a stable IP (HAOS ignores cloud-init networking)."
+  type        = string
+  default     = null
+}
+
+variable "cores" {
+  description = "Number of CPU cores"
+  type        = number
+  default     = 2
+}
+
+variable "memory" {
+  description = "Dedicated memory in MiB"
+  type        = number
+  default     = 2048
+}
+
+variable "disk_size" {
+  description = "Primary disk size in GiB. Set explicitly: the provider defaults qcow2 imports to 8G."
+  type        = number
+  default     = 32
+}
+
+variable "datastore_id" {
+  description = "Datastore for the VM disk and EFI disk"
+  type        = string
+  default     = "local-zfs"
+}
+
+variable "bridge" {
+  description = "Network bridge for the NIC"
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "description" {
+  description = "Free-text description shown in the Proxmox UI"
+  type        = string
+  default     = "Home Assistant OS"
+}
+
+variable "tags" {
+  description = "Tags applied to the VM"
+  type        = list(string)
+  default     = ["terraform"]
+}
+
+variable "on_boot" {
+  description = "Start the VM automatically when the node boots"
+  type        = bool
+  default     = true
+}
+
+variable "started" {
+  description = "Whether the VM should be running"
+  type        = bool
+  default     = true
+}
+
+variable "startup_order" {
+  description = "Boot/shutdown order. When null, no startup config is set."
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
## What

Defines the Home Assistant OS VM as code in `terraform/proxmox/` instead of hand-built in Proxmox. Adds a **dedicated `modules/haos`** plus `homeassistant.tf` (vm **205** → `192.168.0.205`), kept separate from the running **vm 101** until cutover.

## Why a separate module (not `modules/vm`)

`modules/vm` is hardwired for the Debian flow — it `clone`s the cloud-init template and injects an SSH user via cloud-init. HAOS is an **appliance image**, so it:
- is **imported** from a qcow2, never cloned
- has **no SSH user** and ignores Proxmox cloud-init networking
- needs an explicit **EFI disk** and **USB passthrough** the shared module doesn't model
- involves **no Ansible** — there's no host to configure

## Design notes

- **Manual image prep is forced**: bpg `download_file` decompresses gz/lzo/zst/bz2 but **not xz**, and HAOS only ships `.qcow2.xz`. So the image is `unxz`'d + uploaded once, then imported via `disk.import_from`.
- `lifecycle.ignore_changes` on the import so HAOS self-updates in-place don't trigger a re-import.
- `efi_disk` with `pre_enrolled_keys=false` (avoids the known HAOS-on-Proxmox UEFI-shell boot snag).
- **USB inlined**: `1a86:55d4` — the CH9102 serial chip in the Sonoff ZBDongle-E. Pinned by vendor:product so it survives re-plugging (don't pin a second CH340/CH9102 device the same way).
- **MAC auto-assigned** (HAOS can't take a cloud-init static IP like the Debian VMs). After apply, read the `homeassistant_mac` output and add a DHCP reservation → `.205`.
- Values are **inlined in `homeassistant.tf`** matching the per-VM file convention — no root variables.
- Mirrors vm 101 hardware: 2c / 2G / 32G, virtio-scsi, ovmf/q35, ssd+discard+writethrough.

Validated against the pinned `bpg ~> 0.109` provider (`terraform validate` ✓, `fmt` clean).

## Before `terraform apply` — one value to fill

`haos_image_file_id` in `homeassistant.tf`, after downloading + `unxz`'ing the HAOS qcow2 onto the node (e.g. `local:iso/haos_ova-16.0.qcow2`).

## Cutover (full runbook in `plans/homeassistant-haos-terraform.md`)

1. `apply` → vm 205 boots HAOS
2. onboarding → **Restore from backup**
3. short window: stop 101 (frees the dongle) → 205 grabs it → verify radios
4. decommission 101 manually (it's not in TF state)
5. `terraform output homeassistant_mac` → add DHCP reservation → `.205`
6. update the `home-assistant` MCP endpoint to `.205` (token survives in the backup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)