### PR TITLE
Default Hermes to a free OpenRouter model for testing

### DIFF
--- a/config/hermes/cli-config.yaml.j2
+++ b/config/hermes/cli-config.yaml.j2
@@ -1,7 +1,9 @@
 # Hermes Agent configuration — rendered by tasks/docker/hermes.yml
 # Model defaults to OpenRouter; the OPENROUTER_API_KEY env var supplies the key.
+# Using a free, tool-calling-capable model for testing. Free model slugs drift —
+# verify the exact ":free" id and tool-calling support at https://openrouter.ai/models
 model:
-  default: "anthropic/claude-opus-4.6"
+  default: "qwen/qwen3-coder:free"
   provider: "auto"
   base_url: "https://openrouter.ai/api/v1"
 


### PR DESCRIPTION
## Summary

Switch the Hermes default model from `anthropic/claude-opus-4.6` to **`qwen/qwen3-coder:free`** so the agent can be tested via OpenRouter at no cost.

`qwen/qwen3-coder:free` is a free, **tool-calling-capable** model — important because Hermes needs function/tool calling to actually use the MCP tools federated through mcpjungle (Sonarr/Radarr). A free model without tool support would connect but couldn't drive the agent.

## Notes / caveats

- Still requires `OPENROUTER_API_KEY` in the vault (free key, no card needed).
- Free tier is rate-limited (~20 req/min; ~50/day unless ≥10 credits have been purchased, then ~1000/day) — an agentic tool loop can burn through these quickly.
- Free model slugs drift; verify the exact `:free` id and tool-calling capability at [openrouter.ai/models](https://openrouter.ai/models) (Price → Free) if it stops resolving.
- Bump back to a paid model (e.g. `anthropic/claude-opus-4.6`) once testing is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa2HM99kFArByvJ2W9d9Fb)_