### PR TITLE
chore: migrate profilarr to v2

### DIFF
--- a/tasks/docker/profilarr.yml
+++ b/tasks/docker/profilarr.yml
@@ -13,7 +13,7 @@
 - name: PROFILARR - Create container
   community.docker.docker_container:
     name: profilarr
-    image: santiagosayshey/profilarr:v1.1.5
+    image: ghcr.io/dictionarry-hub/profilarr:latest
     restart_policy: always
     state: started
     pull: true


### PR DESCRIPTION
Migrates Profilarr from santiagosayshey/profilarr:v1.1.5 to ghcr.io/dictionarry-hub/profilarr:latest.