### PR TITLE
Update pubgolf backend/frontend images to ed24ae8

### DIFF
--- a/tasks/docker/pubgolf-backend.yml
+++ b/tasks/docker/pubgolf-backend.yml
@@ -13,7 +13,7 @@
 - name: PUBGOLF-BACKEND - Create container
   community.docker.docker_container:
     name: pubgolf-backend
-    image: ghcr.io/bensuskins/pubgolf-backend:dd36907
+    image: ghcr.io/bensuskins/pubgolf-backend:ed24ae8
     restart_policy: always
     state: started
     pull: true

--- a/tasks/docker/pubgolf-frontend.yml
+++ b/tasks/docker/pubgolf-frontend.yml
@@ -2,7 +2,7 @@
 - name: PUBGOLF-FRONTEND - Create container
   community.docker.docker_container:
     name: pubgolf-frontend
-    image: ghcr.io/bensuskins/pubgolf-frontend:b790ecb
+    image: ghcr.io/bensuskins/pubgolf-frontend:ed24ae8
     restart_policy: always
     state: started
     pull: true


### PR DESCRIPTION
## Summary
- Bump `pubgolf-backend` image to `ghcr.io/bensuskins/pubgolf-backend:ed24ae8`
- Bump `pubgolf-frontend` image to `ghcr.io/bensuskins/pubgolf-frontend:ed24ae8`

## Test plan
- [ ] `update.yml` runs successfully on merge to `main` and pulls/restarts both containers with the new image tags


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQkS6FA8KaGgsZVV49rdh6)_