### PR TITLE
Reduce deploy downtime: gate reboots on the OS, pre-pull images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,14 +51,18 @@ For CI/CD, vault password is read from `~/.ansible_vault_pass` file.
 
 Each container task file in `tasks/docker/` follows a standard pattern:
 1. Create directory with permissions
-2. Create container using `community.docker.docker_container`
-3. Define service entry with metadata (name, ip, port, scheme, etc.)
-4. Append to `docker_services` list for Homepage integration
+2. Pre-pull the image using `community.docker.docker_image` (`source: pull`, `force_source: true`), so the download happens before the old container is stopped and the stop→start window stays minimal
+3. Create container using `community.docker.docker_container` with `pull: false`
+4. Define service entry with metadata (name, ip, port, scheme, etc.)
+5. Append to `docker_services` list for Homepage integration
+
+The pre-pull task holds the image reference in a task-level `vars: image:` key and the container task repeats the same literal in its `image:` parameter — Renovate matches `image:` lines, so both are updated together. Keep the two in sync when editing manually.
 
 Example structure:
 ```yaml
 - name: Create directory
-- name: Create container
+- name: Pre-pull image (docker_image with vars: image: repo/name:tag)
+- name: Create container (docker_container with image: repo/name:tag, pull: false)
 - name: Define service entry (set_fact with name, ip, port, etc.)
 - name: Append to docker_services
 ```

--- a/plays/update.yml
+++ b/plays/update.yml
@@ -32,19 +32,16 @@
     - name: UPDATE - Update packages
       ansible.builtin.apt:
         update_cache: true
-      register: apt_update_res
       tags: [packages]
 
     - name: UPDATE - Upgrade packages
       ansible.builtin.apt:
         upgrade: dist
-      register: apt_upgrade_res
       tags: [packages]
 
     - name: UPDATE - Update firewall
       ansible.builtin.include_tasks:
         file: "../tasks/other/firewall.yml"
-      register: firewall_results
       when: firewall | default(false) | bool
       tags: [firewall]
 
@@ -83,7 +80,6 @@
           loop: "{{ core_containers | default([]) }}"
           loop_control:
             loop_var: container
-          register: core_results
 
         - name: UPDATE - Update Docker Containers
           ansible.builtin.include_tasks:
@@ -91,7 +87,6 @@
           loop: "{{ containers | default([]) }}"
           loop_control:
             loop_var: container
-          register: containers_results
 
         - name: UPDATE - Update Special Containers
           ansible.builtin.include_tasks:
@@ -99,7 +94,6 @@
           loop: "{{ special_containers | default([]) }}"
           loop_control:
             loop_var: container
-          register: special_results
 
         - name: UPDATE - Get all containers
           community.docker.docker_host_info:
@@ -114,7 +108,6 @@
           loop_control:
             label: "{{ item.Names[0] | default('unknown') }}"
           when: (item.Names[0] | regex_replace('^/', '')) not in expected_containers
-          register: remove_results
       rescue:
         - name: UPDATE - Report docker failure
           ansible.builtin.fail:
@@ -133,21 +126,18 @@
       run_once: true
       tags: [docs]
 
-    - name: UPDATE - Set reboot_required if important tasks changed
-      ansible.builtin.set_fact:
-        reboot_required: true
-      when: >
-        (apt_update_res.changed | default(false)) or
-        (apt_upgrade_res.changed | default(false)) or
-        (firewall_results.changed | default(false)) or
-        (core_results.changed | default(false)) or
-        (containers_results.changed | default(false)) or
-        (special_results.changed | default(false)) or
-        (remove_results.changed | default(false))
+    - name: UPDATE - Check if the OS requires a reboot
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: reboot_required_file
       tags: [reboot]
 
+    # throttle keeps reboots to one host at a time so the rest of the lab
+    # stays reachable; serial can't be used because service aggregation
+    # needs docker_services facts from every host in the same batch.
     - name: UPDATE - Reboot server
       ansible.builtin.reboot:
         msg: "Rebooting server after update"
-      when: reboot_required | default(false)
+      when: reboot_required_file.stat.exists
+      throttle: 1
       tags: [reboot]

--- a/tasks/docker/adguard.yml
+++ b/tasks/docker/adguard.yml
@@ -46,13 +46,21 @@
     state: restarted
   when: adguard_resolved_stub.changed
 
+- name: ADGUARD - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: adguard/adguardhome:v0.107.78
+
 - name: ADGUARD - Create container
   community.docker.docker_container:
     name: adguard
     image: adguard/adguardhome:v0.107.78
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     ports:
       - "53:53/tcp"
       - "53:53/udp"

--- a/tasks/docker/alloy.yml
+++ b/tasks/docker/alloy.yml
@@ -105,13 +105,21 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: ALLOY - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: grafana/alloy:v1.17.1
+
 - name: ALLOY - Create container
   community.docker.docker_container:
     name: alloy
     image: grafana/alloy:v1.18.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     command: run /etc/alloy/config/config.alloy

--- a/tasks/docker/alloy.yml
+++ b/tasks/docker/alloy.yml
@@ -111,7 +111,7 @@
     source: pull
     force_source: true
   vars:
-    image: grafana/alloy:v1.17.1
+    image: grafana/alloy:v1.18.0
 
 - name: ALLOY - Create container
   community.docker.docker_container:

--- a/tasks/docker/authelia.yml
+++ b/tasks/docker/authelia.yml
@@ -26,13 +26,21 @@
     mode: "0600"
   when: not users_database.stat.exists
 
+- name: AUTHELIA - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: authelia/authelia:4.39.20
+
 - name: AUTHELIA - Create container
   community.docker.docker_container:
     name: authelia
     image: authelia/authelia:4.39.20
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     ports:
       - "9091:9091"
     networks:

--- a/tasks/docker/bazarr.yml
+++ b/tasks/docker/bazarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/bazarr"
 
+- name: BAZARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/linuxserver/bazarr:1.6.0
+
 - name: BAZARR - Create container
   community.docker.docker_container:
     name: bazarr
     image: ghcr.io/linuxserver/bazarr:1.6.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/calibre-web-automated.yml
+++ b/tasks/docker/calibre-web-automated.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/calibre-web-automated"
 
+- name: CALIBRE WEB AUTOMATED - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: crocodilestick/calibre-web-automated:v4.0.6
+
 - name: CALIBRE WEB AUTOMATED - Create container
   community.docker.docker_container:
     name: calibre-web-automated
     image: crocodilestick/calibre-web-automated:v4.0.6
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/cleanuparr.yml
+++ b/tasks/docker/cleanuparr.yml
@@ -16,7 +16,7 @@
     source: pull
     force_source: true
   vars:
-    image: ghcr.io/cleanuparr/cleanuparr:2.9.16
+    image: ghcr.io/cleanuparr/cleanuparr:2.10.0
 
 - name: CLEANUPARR - Create container
   community.docker.docker_container:

--- a/tasks/docker/cleanuparr.yml
+++ b/tasks/docker/cleanuparr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/cleanuparr"
 
+- name: CLEANUPARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/cleanuparr/cleanuparr:2.9.16
+
 - name: CLEANUPARR - Create container
   community.docker.docker_container:
     name: cleanuparr
     image: ghcr.io/cleanuparr/cleanuparr:2.10.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/cloudflare-ddns.yml
+++ b/tasks/docker/cloudflare-ddns.yml
@@ -1,11 +1,19 @@
 ---
+- name: CLOUDFLARE-DDNS - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: favonia/cloudflare-ddns:1.16.2
+
 - name: CLOUDFLARE-DDNS - Create container
   community.docker.docker_container:
     name: cloudflare-ddns
     image: favonia/cloudflare-ddns:1.16.2
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     env:

--- a/tasks/docker/doplarr.yml
+++ b/tasks/docker/doplarr.yml
@@ -19,13 +19,21 @@
     group: "{{ username }}"
     mode: "0640"
 
+- name: DOPLARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/activexray/doplarr_rs:latest
+
 - name: DOPLARR - Create container
   community.docker.docker_container:
     name: doplarr
     image: ghcr.io/activexray/doplarr_rs:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     env:

--- a/tasks/docker/family-hub.yml
+++ b/tasks/docker/family-hub.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/family-hub"
 
+- name: FAMILY-HUB - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/family-hub:latest
+
 - name: FAMILY-HUB - Create container
   community.docker.docker_container:
     name: family-hub
     image: ghcr.io/bensuskins/family-hub:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     volumes:

--- a/tasks/docker/flaresolverr.yml
+++ b/tasks/docker/flaresolverr.yml
@@ -1,11 +1,19 @@
 ---
+- name: FLARESOLVERR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
+
 - name: FLARESOLVERR - Create container
   community.docker.docker_container:
     name: flaresolverr
     image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     memory: 1g
     cpus: "1.0"
     networks:

--- a/tasks/docker/gatus.yml
+++ b/tasks/docker/gatus.yml
@@ -23,13 +23,21 @@
   vars:
     monitored_services: "{{ all_services | default([]) }}"
 
+- name: GATUS - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: twinproduction/gatus:v5.36.0
+
 - name: GATUS - Create container
   community.docker.docker_container:
     name: gatus
     image: twinproduction/gatus:v5.36.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     ports:
       - "8080:8080"
     networks:

--- a/tasks/docker/gluetun.yml
+++ b/tasks/docker/gluetun.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/gluetun"
 
+- name: GLUETUN - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: qmcgaw/gluetun:v3.41.1
+
 - name: GLUETUN - Create container
   community.docker.docker_container:
     name: gluetun
     image: qmcgaw/gluetun:v3.41.1
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     capabilities:
       - NET_ADMIN
     devices:

--- a/tasks/docker/grafana.yml
+++ b/tasks/docker/grafana.yml
@@ -19,13 +19,21 @@
     group: "472"
     mode: "0644"
 
+- name: GRAFANA - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: grafana/grafana:13.1.0
+
 - name: GRAFANA - Create container
   community.docker.docker_container:
     name: grafana
     image: grafana/grafana:13.1.1
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     ports:
       - "3000:3000"
     networks:

--- a/tasks/docker/grafana.yml
+++ b/tasks/docker/grafana.yml
@@ -25,7 +25,7 @@
     source: pull
     force_source: true
   vars:
-    image: grafana/grafana:13.1.0
+    image: grafana/grafana:13.1.1
 
 - name: GRAFANA - Create container
   community.docker.docker_container:

--- a/tasks/docker/graphite-exporter.yml
+++ b/tasks/docker/graphite-exporter.yml
@@ -88,13 +88,21 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: GRAPHITE-EXPORTER - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: prom/graphite-exporter:v0.17.0
+
 - name: GRAPHITE-EXPORTER - Create container
   community.docker.docker_container:
     name: graphite-exporter
     image: prom/graphite-exporter:v0.17.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/hermes.yml
+++ b/tasks/docker/hermes.yml
@@ -5,7 +5,7 @@
     source: pull
     force_source: true
   vars:
-    image: nousresearch/hermes-agent:v2026.7.7
+    image: nousresearch/hermes-agent:v2026.7.20
 
 - name: HERMES - Create container
   community.docker.docker_container:

--- a/tasks/docker/hermes.yml
+++ b/tasks/docker/hermes.yml
@@ -1,11 +1,19 @@
 ---
+- name: HERMES - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: nousresearch/hermes-agent:v2026.7.7
+
 - name: HERMES - Create container
   community.docker.docker_container:
     name: hermes
     image: nousresearch/hermes-agent:v2026.7.20
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     command: gateway run

--- a/tasks/docker/homepage.yml
+++ b/tasks/docker/homepage.yml
@@ -42,13 +42,21 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: HOMEPAGE - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/gethomepage/homepage:v1.13.2
+
 - name: HOMEPAGE - Create container
   community.docker.docker_container:
     name: homepage
     image: ghcr.io/gethomepage/homepage:v1.13.2
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     env:
       HOMEPAGE_ALLOWED_HOSTS: "{{ docker_ip }}:3000,home.{{ domain }}"
     networks:

--- a/tasks/docker/loki.yml
+++ b/tasks/docker/loki.yml
@@ -57,7 +57,7 @@
     source: pull
     force_source: true
   vars:
-    image: grafana/loki:3.7.3
+    image: grafana/loki:3.7.4
 
 - name: LOKI - Create container
   community.docker.docker_container:

--- a/tasks/docker/loki.yml
+++ b/tasks/docker/loki.yml
@@ -51,13 +51,21 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: LOKI - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: grafana/loki:3.7.3
+
 - name: LOKI - Create container
   community.docker.docker_container:
     name: loki
     image: grafana/loki:3.7.4
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     ports:
       - "3100:3100"
     networks:

--- a/tasks/docker/mcpjungle.yml
+++ b/tasks/docker/mcpjungle.yml
@@ -8,13 +8,21 @@
     group: "{{ username }}"
     mode: "0750"
 
+- name: MCPJUNGLE - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/mcpjungle/mcpjungle:latest
+
 - name: MCPJUNGLE - Create container
   community.docker.docker_container:
     name: mcpjungle
     image: ghcr.io/mcpjungle/mcpjungle:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/media-server-mcp.yml
+++ b/tasks/docker/media-server-mcp.yml
@@ -1,11 +1,19 @@
 ---
+- name: MEDIA-SERVER-MCP - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/media-server-mcp:latest
+
 - name: MEDIA-SERVER-MCP - Create container
   community.docker.docker_container:
     name: media-server-mcp
     image: ghcr.io/bensuskins/media-server-mcp:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/metube.yml
+++ b/tasks/docker/metube.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/metube"
 
+- name: METUBE - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/alexta69/metube:2025-03-07
+
 - name: METUBE - Create container
   community.docker.docker_container:
     name: metube
     image: ghcr.io/alexta69/metube:2025-03-07
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/open-books.yml
+++ b/tasks/docker/open-books.yml
@@ -1,11 +1,19 @@
 ---
+- name: OPEN BOOKS - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: evanbuss/openbooks:4.5.0
+
 - name: OPEN BOOKS - Create container
   community.docker.docker_container:
     name: open-books
     image: evanbuss/openbooks:4.5.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/plex.yml
+++ b/tasks/docker/plex.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/plex"
 
+- name: PLEX - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/linuxserver/plex:1.43.3
+
 - name: PLEX - Create container
   community.docker.docker_container:
     name: plex
     image: ghcr.io/linuxserver/plex:1.43.3
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     network_mode: host
     volumes:
       - "{{ base_dir }}/plex:/config"

--- a/tasks/docker/profilarr.yml
+++ b/tasks/docker/profilarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/profilarr"
 
+- name: PROFILARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/dictionarry-hub/profilarr:latest
+
 - name: PROFILARR - Create container
   community.docker.docker_container:
     name: profilarr
     image: ghcr.io/dictionarry-hub/profilarr:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/prometheus.yml
+++ b/tasks/docker/prometheus.yml
@@ -30,13 +30,21 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: PROMETHEUS - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: prom/prometheus:v3.13.1
+
 - name: PROMETHEUS - Create container
   community.docker.docker_container:
     name: prometheus
     image: prom/prometheus:v3.13.1
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--web.enable-remote-write-receiver"

--- a/tasks/docker/prowlarr.yml
+++ b/tasks/docker/prowlarr.yml
@@ -16,7 +16,7 @@
     source: pull
     force_source: true
   vars:
-    image: ghcr.io/linuxserver/prowlarr:2.4.0
+    image: ghcr.io/linuxserver/prowlarr:2.5.2
 
 - name: PROWLARR - Create container
   community.docker.docker_container:

--- a/tasks/docker/prowlarr.yml
+++ b/tasks/docker/prowlarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/prowlarr"
 
+- name: PROWLARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/linuxserver/prowlarr:2.4.0
+
 - name: PROWLARR - Create container
   community.docker.docker_container:
     name: prowlarr
     image: ghcr.io/linuxserver/prowlarr:2.5.2
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/pubgolf-backend.yml
+++ b/tasks/docker/pubgolf-backend.yml
@@ -16,7 +16,7 @@
     source: pull
     force_source: true
   vars:
-    image: ghcr.io/bensuskins/pubgolf-backend:a893647
+    image: ghcr.io/bensuskins/pubgolf-backend:latest
 
 - name: PUBGOLF-BACKEND - Create container
   community.docker.docker_container:

--- a/tasks/docker/pubgolf-backend.yml
+++ b/tasks/docker/pubgolf-backend.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/pubgolf"
 
+- name: PUBGOLF-BACKEND - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/pubgolf-backend:a893647
+
 - name: PUBGOLF-BACKEND - Create container
   community.docker.docker_container:
     name: pubgolf-backend
     image: ghcr.io/bensuskins/pubgolf-backend:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     volumes:

--- a/tasks/docker/pubgolf-frontend.yml
+++ b/tasks/docker/pubgolf-frontend.yml
@@ -1,11 +1,19 @@
 ---
+- name: PUBGOLF-FRONTEND - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/pubgolf-frontend:4f59462
+
 - name: PUBGOLF-FRONTEND - Create container
   community.docker.docker_container:
     name: pubgolf-frontend
     image: ghcr.io/bensuskins/pubgolf-frontend:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/pubgolf-frontend.yml
+++ b/tasks/docker/pubgolf-frontend.yml
@@ -5,7 +5,7 @@
     source: pull
     force_source: true
   vars:
-    image: ghcr.io/bensuskins/pubgolf-frontend:4f59462
+    image: ghcr.io/bensuskins/pubgolf-frontend:latest
 
 - name: PUBGOLF-FRONTEND - Create container
   community.docker.docker_container:

--- a/tasks/docker/qbittorrent.yml
+++ b/tasks/docker/qbittorrent.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/qbittorrent"
 
+- name: QBITTORRENT - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: lscr.io/linuxserver/qbittorrent:latest
+
 - name: QBITTORRENT - Create container
   community.docker.docker_container:
     name: qbittorrent
     image: lscr.io/linuxserver/qbittorrent:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     network_mode: container:gluetun
     volumes:
       - "{{ base_dir }}/qbittorrent:/config"

--- a/tasks/docker/radarr.yml
+++ b/tasks/docker/radarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/radarr"
 
+- name: RADARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/linuxserver/radarr:6.3.0
+
 - name: RADARR - Create container
   community.docker.docker_container:
     name: radarr
     image: ghcr.io/linuxserver/radarr:6.3.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/redis.yml
+++ b/tasks/docker/redis.yml
@@ -8,13 +8,21 @@
   loop:
     - "{{ base_dir }}/redis/data"
 
+- name: REDIS - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: redis:7.4-alpine
+
 - name: REDIS - Create container
   community.docker.docker_container:
     name: redis
     image: redis:7.4-alpine
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     command: redis-server --appendonly yes
     networks:
       - name: homelab

--- a/tasks/docker/seerr.yml
+++ b/tasks/docker/seerr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/overseer"
 
+- name: SEERR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/seerr-team/seerr:v3.3.0
+
 - name: SEERR - Create container
   community.docker.docker_container:
     name: seerr
     image: ghcr.io/seerr-team/seerr:v3.3.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/shelfmark.yml
+++ b/tasks/docker/shelfmark.yml
@@ -16,7 +16,7 @@
     source: pull
     force_source: true
   vars:
-    image: ghcr.io/calibrain/shelfmark:v1.3.3
+    image: ghcr.io/calibrain/shelfmark:v1.3.4
 
 - name: SHELFMARK - Create container
   community.docker.docker_container:

--- a/tasks/docker/shelfmark.yml
+++ b/tasks/docker/shelfmark.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/shelfmark"
 
+- name: SHELFMARK - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/calibrain/shelfmark:v1.3.3
+
 - name: SHELFMARK - Create container
   community.docker.docker_container:
     name: shelfmark
     image: ghcr.io/calibrain/shelfmark:v1.3.4
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/sonarr.yml
+++ b/tasks/docker/sonarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/sonarr"
 
+- name: SONARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/linuxserver/sonarr:4.0.19
+
 - name: SONARR - Create container
   community.docker.docker_container:
     name: sonarr
     image: ghcr.io/linuxserver/sonarr:4.0.19
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/sportarr.yml
+++ b/tasks/docker/sportarr.yml
@@ -10,13 +10,21 @@
   loop:
     - "{{ base_dir }}/sportarr"
 
+- name: SPORTARR - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: sportarr/sportarr:4.0
+
 - name: SPORTARR - Create container
   community.docker.docker_container:
     name: sportarr
     image: sportarr/sportarr:4.0
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/traefik.yml
+++ b/tasks/docker/traefik.yml
@@ -67,13 +67,21 @@
   vars:
     all_services: "{{ all_docker_services }}"
 
+- name: TRAEFIK - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: "traefik:v3.7"
+
 - name: TRAEFIK - Deploy container
   community.docker.docker_container:
     name: traefik
     image: "traefik:v3.7"
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     command: >

--- a/tasks/docker/wedding-db.yml
+++ b/tasks/docker/wedding-db.yml
@@ -7,13 +7,21 @@
 #     owner: "999"
 #     group: "999"
 
+- name: WEDDING-DB - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: postgres:16-alpine
+
 - name: WEDDING-DB - Create container
   community.docker.docker_container:
     name: wedding-db
     image: postgres:16-alpine
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     volumes:

--- a/tasks/docker/wedding.yml
+++ b/tasks/docker/wedding.yml
@@ -10,13 +10,21 @@
 #   loop:
 #     - "{{ base_dir }}/wedding/uploads"
 
+- name: WEDDING - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/wedding:latest
+
 - name: WEDDING - Create container
   community.docker.docker_container:
     name: wedding
     image: ghcr.io/bensuskins/wedding:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:

--- a/tasks/docker/workboard-mcp.yml
+++ b/tasks/docker/workboard-mcp.yml
@@ -8,13 +8,21 @@
     group: "{{ username }}"
     mode: "0750"
 
+- name: WORKBOARD-MCP - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/workboard:latest
+
 - name: WORKBOARD-MCP - Create container
   community.docker.docker_container:
     name: workboard-mcp
     image: ghcr.io/bensuskins/workboard:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     command: npx tsx packages/mcp/src/http.ts

--- a/tasks/docker/workboard.yml
+++ b/tasks/docker/workboard.yml
@@ -8,13 +8,21 @@
     group: "{{ username }}"
     mode: "0750"
 
+- name: WORKBOARD - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/workboard:latest
+
 - name: WORKBOARD - Create container
   community.docker.docker_container:
     name: workboard
     image: ghcr.io/bensuskins/workboard:latest
     restart_policy: always
     state: started
-    pull: true
+    pull: false
     networks:
       - name: homelab
     ports:


### PR DESCRIPTION
Tier 1 of the zero-downtime deploy plan (without health gating).

## What was wrong

`plays/update.yml` set `reboot_required` whenever *any* task reported changed — including a routine Renovate image bump — so every deploy rebooted every host, and all hosts rebooted in parallel. That took Traefik and every proxied service down at once on essentially every run.

## Changes

**`plays/update.yml`**
- Reboot only when `/var/run/reboot-required` exists (written by apt after kernel/libc updates), replacing the changed-status conditional. The now-unused `register:` vars on the apt/firewall/container tasks are dropped.
- `throttle: 1` on the reboot task so at most one host is down at a time. `serial: 1` was deliberately **not** used: `aggregate_services.yml` reads `docker_services` facts from every host, and under `serial` the first batch would template Traefik/Gatus/Homepage configs missing every not-yet-processed host's services.

**`tasks/docker/*.yml` (39 files)**
- Each container task file now pre-pulls its image with `community.docker.docker_image` (`source: pull`, `force_source: true`) before the `docker_container` task, which is switched to `pull: false`. Image downloads can never sit inside the container's stop→start window, and a failed pull aborts before the running container is touched. The forced pull keeps mutable tags (`:latest`, `traefik:v3.7`, `postgres:16-alpine`, `redis:7.4-alpine`) picking up new digests, matching the old `pull: true` behaviour.
- The pre-pull task holds the image reference under a task-level `vars: image:` key. Renovate's ansible manager matches `image:` lines regardless of nesting, so both occurrences update together in the existing "Ansible Docker Images" group.

**`CLAUDE.md`**
- Container task pattern docs updated to include the pre-pull step and the Renovate pairing note.

## Verification

- `ansible-playbook --syntax-check` passes for `plays/update.yml` and `plays/setup.yml`.
- `ansible-lint` reports exactly the same 5 pre-existing findings before and after this change (nothing new introduced).
- All 39 edited task files parse as valid YAML; `wedding-db-backup.yml` (no container) is untouched.

## Expected behaviour after merge

- Container-only updates: no reboots at all; per-service downtime is just the stop→start of that container (seconds).
- OS updates needing a reboot: hosts reboot one at a time instead of simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAtJS3SPA4FiKabhzLNegM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAtJS3SPA4FiKabhzLNegM)_