### PR TITLE
Update pubgolf backend and frontend to e1649da

### DIFF
--- a/tasks/docker/pubgolf-backend.yml
+++ b/tasks/docker/pubgolf-backend.yml
@@ -13,7 +13,7 @@
 - name: PUBGOLF-BACKEND - Create container
   community.docker.docker_container:
     name: pubgolf-backend
-    image: ghcr.io/bensuskins/pubgolf-backend:a893647
+    image: ghcr.io/bensuskins/pubgolf-backend:e1649da
     restart_policy: always
     state: started
     pull: true

--- a/tasks/docker/pubgolf-frontend.yml
+++ b/tasks/docker/pubgolf-frontend.yml
@@ -2,7 +2,7 @@
 - name: PUBGOLF-FRONTEND - Create container
   community.docker.docker_container:
     name: pubgolf-frontend
-    image: ghcr.io/bensuskins/pubgolf-frontend:4f59462
+    image: ghcr.io/bensuskins/pubgolf-frontend:e1649da
     restart_policy: always
     state: started
     pull: true


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/bensuskins/pubgolf-backend` image tag from `a893647` to `e1649da`
- Bump `ghcr.io/bensuskins/pubgolf-frontend` image tag from `4f59462` to `e1649da`

## Test plan
- [ ] `ansible-playbook plays/deploy-containers.yml --ask-vault-pass` deploys the updated images successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_01CicqtKPJGXDhnjEqY1KofA)_