### PR TITLE
Use latest tag for pubgolf backend and frontend

### DIFF
--- a/tasks/docker/pubgolf-backend.yml
+++ b/tasks/docker/pubgolf-backend.yml
@@ -13,7 +13,7 @@
 - name: PUBGOLF-BACKEND - Create container
   community.docker.docker_container:
     name: pubgolf-backend
-    image: ghcr.io/bensuskins/pubgolf-backend:e1649da
+    image: ghcr.io/bensuskins/pubgolf-backend:latest
     restart_policy: always
     state: started
     pull: true

--- a/tasks/docker/pubgolf-frontend.yml
+++ b/tasks/docker/pubgolf-frontend.yml
@@ -2,7 +2,7 @@
 - name: PUBGOLF-FRONTEND - Create container
   community.docker.docker_container:
     name: pubgolf-frontend
-    image: ghcr.io/bensuskins/pubgolf-frontend:e1649da
+    image: ghcr.io/bensuskins/pubgolf-frontend:latest
     restart_policy: always
     state: started
     pull: true


### PR DESCRIPTION
Switches both pubgolf container images from the pinned `e1649da` tag to `latest`.

## Changes

- `tasks/docker/pubgolf-backend.yml` — `ghcr.io/bensuskins/pubgolf-backend:e1649da` → `:latest`
- `tasks/docker/pubgolf-frontend.yml` — `ghcr.io/bensuskins/pubgolf-frontend:e1649da` → `:latest`

Both containers already set `pull: true`, so each deploy will fetch the newest published image and recreate the container when the image ID changes.

## Note

Renovate tracks Docker image versions in `tasks/docker/*.yml` and relies on pinned tags — it will no longer open update PRs for these two images now that they float on `latest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyhaYo2tEcYD59Ydp5fcaK)_