### PR TITLE
Allow France in pubgolf.me WAF country rule

### DIFF
--- a/terraform/cloudflare/locals.tf
+++ b/terraform/cloudflare/locals.tf
@@ -11,7 +11,7 @@ locals {
     pubgolf = {
       zone_id           = data.cloudflare_zone.pubgolf.zone_id
       hostname          = "pubgolf.me"
-      allowed_countries = ["GB"]
+      allowed_countries = ["GB", "FR"]
     }
   }
 }


### PR DESCRIPTION
## What

Adds `FR` to `allowed_countries` for the `pubgolf` zone in `terraform/cloudflare/locals.tf`.

## Why

The custom WAF ruleset in `terraform/cloudflare/waf.tf` has a "Block countries outside the allowed list" rule that builds its expression from each zone's `allowed_countries` list:

```
(not ip.src.country in {"GB"})
```

`suskins.co.uk` already allowed `["GB", "FR"]`; `pubgolf.me` was UK-only. This brings the two zones in line so France is permitted on both.

## Effect

After apply, the pubgolf.me rule expression becomes `(not ip.src.country in {"GB" "FR"})`. No other rules, zone settings, or DNS records change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfbgA2FrtaToU1yZhboger)_