### PR TITLE
Exempt Cloudflare verified bots from geo-block and challenge rules

### DIFF
--- a/terraform/cloudflare/waf.tf
+++ b/terraform/cloudflare/waf.tf
@@ -40,7 +40,7 @@ resource "cloudflare_ruleset" "waf" {
   rules = [
     {
       description = "Block countries outside the allowed list"
-      expression  = "(not ip.src.country in {${join(" ", [for c in each.value.allowed_countries : "\"${c}\""])}})"
+      expression  = "(not ip.src.country in {${join(" ", [for c in each.value.allowed_countries : "\"${c}\""])}}) and not cf.client.bot"
       action      = "block"
       enabled     = true
     },
@@ -58,7 +58,7 @@ resource "cloudflare_ruleset" "waf" {
     },
     {
       description = "Managed Challenge for suspicious requests (high threat score or Tor)"
-      expression  = "(cf.threat_score gt 10) or (ip.src.country eq \"T1\")"
+      expression  = "((cf.threat_score gt 10) or (ip.src.country eq \"T1\")) and not cf.client.bot"
       action      = "managed_challenge"
       enabled     = true
     },


### PR DESCRIPTION
## Why
pubgolf.me is completely unindexed — Google Search Console reports every page as "Blocked due to access forbidden (403)". The WAF country allowlist (`GB`/`FR`) hard-blocks Googlebot and Bingbot, which crawl from US IP ranges.

## What
- Append `and not cf.client.bot` to the geo-block rule so Cloudflare **verified** bots (validated by reverse DNS — unspoofable) bypass the country restriction. Humans outside GB/FR are still blocked.
- Same exemption on the managed-challenge rule: crawlers can't solve challenges, so a challenge is an effective block.

Applies to both `suskins` and `pubgolf` zones via the shared ruleset.

## After merge
- CI applies the ruleset change.
- Then in GSC: URL Inspection → Live Test on https://pubgolf.me/ should return 200, request indexing + resubmit sitemap.
- Worth checking the Cloudflare dashboard that Bot Fight Mode is off and Security Level isn't high for the pubgolf.me zone — neither is managed in Terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVDj1WQuxkkV3YZACUKA9t