### PR TITLE
feat: add Tailscale subnet router for remote access

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,6 +20,9 @@ env:
   TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   TF_VAR_proxmox_api_token: ${{ secrets.PROXMOX_API_TOKEN }}
   TF_VAR_proxmox_endpoint: ${{ secrets.PROXMOX_ENDPOINT }}
+  TF_VAR_tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+  TF_VAR_tailscale_oauth_client_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+  TF_VAR_tailscale_tag_owner: ${{ secrets.TAILSCALE_TAG_OWNER }}
 
 jobs:
   plan-pr:
@@ -28,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dir: [cloudflare, proxmox]
+        dir: [cloudflare, proxmox, tailscale]
     defaults:
       run:
         working-directory: terraform/${{ matrix.dir }}
@@ -130,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dir: [cloudflare, proxmox]
+        dir: [cloudflare, proxmox, tailscale]
     defaults:
       run:
         working-directory: terraform/${{ matrix.dir }}
@@ -168,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dir: [cloudflare, proxmox]
+        dir: [cloudflare, proxmox, tailscale]
     defaults:
       run:
         working-directory: terraform/${{ matrix.dir }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Each container task file in `tasks/docker/` follows a standard pattern:
 
 The pre-pull task holds the image reference in a task-level `vars: image:` key and the container task repeats the same literal in its `image:` parameter — Renovate matches `image:` lines, so both are updated together. Keep the two in sync when editing manually.
 
+A container task file may also carry host-level prerequisites for that container, so they only apply where the container is registered: `adguard.yml` disables the systemd-resolved stub listener to free port 53, and `tailscale.yml` loads the `tun` module and enables `net.ipv4.ip_forward` for subnet routing.
+
 Example structure:
 ```yaml
 - name: Create directory
@@ -147,7 +149,15 @@ The `docker_services` list is aggregated across all hosts via `tasks/core/aggreg
 - Generate Prometheus scrape configs via `config/prometheus/config.yml.j2`
 - Cloudflare DNS records are managed via Terraform in `terraform/cloudflare/`
 
-Proxmox VMs are managed via a separate Terraform root in `terraform/proxmox/` (bpg/proxmox provider). Each Terraform root has its own R2 state key. A single `terraform.yml` workflow runs a matrix (plan → approved apply) over both roots on the `self-hosted` runner, since the Proxmox API is LAN-only. Each VM lives in its own `<name>.tf` file (e.g. `bumblebee.tf`) holding its `module` block and IP `output`; add a new VM by copying the commented template in `terraform/proxmox/vms.tf` into a new per-host file.
+Proxmox VMs are managed via a separate Terraform root in `terraform/proxmox/` (bpg/proxmox provider). Each VM lives in its own `<name>.tf` file (e.g. `bumblebee.tf`) holding its `module` block and IP `output`; add a new VM by copying the commented template in `terraform/proxmox/vms.tf` into a new per-host file.
+
+Tailnet configuration lives in a third root, `terraform/tailscale/` (tailscale/tailscale provider): the policy file (`tag:subnet-router` tag owners plus `autoApprovers` so the advertised LAN route needs no manual approval) and split DNS sending `suskins.co.uk` at AdGuard Home. Note `tailscale_acl` owns the *whole* policy file, so import it before the first apply if the console copy has been hand-edited.
+
+Each Terraform root has its own R2 state key. A single `terraform.yml` workflow runs a matrix (plan → approved apply) over all three roots on the `self-hosted` runner, since the Proxmox API is LAN-only.
+
+### Remote Access
+
+A Tailscale subnet router runs on the `docker` host (`tasks/docker/tailscale.yml`) advertising `192.168.0.0/24`, so every homelab service is reachable remotely with no inbound port forwards. Tailnet split DNS points `suskins.co.uk` at AdGuard Home on the same host, whose `*.suskins.co.uk` rewrite resolves to Traefik — so remote clients get the identical name resolution and TLS path as LAN clients. There is no `tailscale` binary on the host; use `docker exec tailscale tailscale status`.
 
 ### Docker Image Updates
 

--- a/config/readme/ARCHITECTURE.md.j2
+++ b/config/readme/ARCHITECTURE.md.j2
@@ -26,6 +26,7 @@ flowchart LR
     Monitor --> Loki
     Monitor --> Grafana
     Control -.->|Terraform| CF[Cloudflare DNS]
+    Remote[Remote client] -.->|Tailscale subnet route| Docker
 ```
 
 ## Playbooks
@@ -52,6 +53,28 @@ Hosts themselves are provisioned with Terraform (`terraform/proxmox/`,
   VM is reachable for `plays/setup.yml` (base packages + Docker) with no manual prep.
 
 See the [README](README.md#cloud-init-template) for the one-time template build.
+
+## Remote Access
+
+A Tailscale subnet router runs on the `docker` host and advertises the whole home
+LAN (`192.168.0.0/24`), so every service is reachable remotely with **no inbound
+port forwards** — Tailscale makes only outbound connections.
+
+- **Names resolve the same off-LAN as on it.** Tailnet *split DNS* sends
+  `{{ '{{ domain }}' }}` queries to AdGuard Home on the same host, whose
+  `*.{{ '{{ domain }}' }}` rewrite points at Traefik. Only that domain is
+  redirected, so general internet DNS on a remote device is unaffected if the
+  homelab is down.
+- **Terraform-managed.** `terraform/tailscale/` owns the policy file (tag owners
+  plus `autoApprovers`, so the route needs no manual approval after a rebuild) and
+  the split-DNS record.
+- **Ansible-managed.** `tasks/docker/tailscale.yml` runs the container with host
+  networking, `NET_ADMIN` and `/dev/net/tun`, and sets the host's
+  `net.ipv4.ip_forward` that subnet routing requires.
+- Subnet-routed traffic is masqueraded to the router's LAN address, so services
+  behind Traefik see all remote clients as one source IP.
+- There is no `tailscale` binary on the host — use
+  `docker exec tailscale tailscale status`.
 
 ## Service Definition Pattern
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,8 @@ Renovate.
 - `community.docker.docker_container` for container lifecycle
 - Ansible Vault for secrets
 - Renovate for image updates
-- Terraform (in `terraform/cloudflare/`) for Cloudflare DNS and (in `terraform/proxmox/`) for Proxmox VMs
+- Terraform (in `terraform/cloudflare/`) for Cloudflare DNS, (in `terraform/proxmox/`) for Proxmox VMs, and (in `terraform/tailscale/`) for tailnet policy and DNS
+- Tailscale for remote access (subnet router on the `docker` host)
 
 ## Project Structure
 
@@ -46,7 +47,8 @@ Renovate.
 ├── config/                  # Traefik, Gatus, Prometheus, Homepage templates
 ├── terraform/
 │   ├── cloudflare/          # Cloudflare DNS, WAF, zone settings
-│   └── proxmox/             # Proxmox VM definitions (bpg/proxmox)
+│   ├── proxmox/             # Proxmox VM definitions (bpg/proxmox)
+│   └── tailscale/           # Tailnet policy + split DNS (tailscale/tailscale)
 └── vault.yml                # Encrypted secrets
 ```
 
@@ -92,15 +94,16 @@ CI reads the vault password from `~/.ansible_vault_pass`.
 
 ## Infrastructure (Terraform)
 
-Two independent Terraform roots manage cloud/hypervisor infrastructure, each with its
+Three independent Terraform roots manage cloud/hypervisor infrastructure, each with its
 own remote state in Cloudflare R2:
 
 | Root | Manages |
 |------|---------|
 | `terraform/cloudflare/` | Cloudflare DNS, WAF, zone settings |
 | `terraform/proxmox/` | Proxmox VMs (`bpg/proxmox`) |
+| `terraform/tailscale/` | Tailnet policy file and split DNS (`tailscale/tailscale`) |
 
-A single `terraform.yml` workflow runs a **matrix** over both roots (plan →
+A single `terraform.yml` workflow runs a **matrix** over all three roots (plan →
 manually-approved apply against the `production` environment). It runs on the
 **self-hosted** runner because the Proxmox API (`192.168.0.253:8006`) is only reachable
 on the LAN.
@@ -147,6 +150,33 @@ qm set 9000 --ide2 local-zfs:cloudinit
 qm set 9000 --boot c --bootdisk scsi0 --serial0 socket --vga serial0 --agent enabled=1
 qm template 9000
 ```
+
+## Remote Access (Tailscale)
+
+A Tailscale subnet router runs on the `docker` host (`tasks/docker/tailscale.yml`)
+advertising `192.168.0.0/24`, so every service is reachable off-LAN with **no inbound
+port forwards**. Tailnet split DNS points `suskins.co.uk` at AdGuard Home on the same
+host, whose `*.suskins.co.uk` rewrite resolves to Traefik — remote clients therefore
+get exactly the same names, routing and TLS as LAN clients.
+
+The tailnet side (policy file, tag owners, route auto-approval, split DNS) is managed
+by `terraform/tailscale/`.
+
+**Prerequisites** (one-time, outside this repo):
+
+- A Tailscale **auth key**: reusable, pre-approved, **non-ephemeral** (ephemeral nodes
+  are deleted when offline, which would withdraw the route on every reboot), tagged
+  `tag:subnet-router`. Store it in the vault as `TAILSCALE_AUTHKEY`.
+- A Tailscale **OAuth client** with the `devices:core`, `dns` and `policy_file` scopes,
+  for Terraform.
+- GitHub secrets `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET` and
+  `TAILSCALE_TAG_OWNER`.
+- `tag:subnet-router` must exist in the tailnet policy before an auth key can carry it,
+  so apply `terraform/tailscale/` before minting the key.
+
+Linux clients need `tailscale up --accept-routes`; iOS, Android and macOS accept
+advertised routes by default. There is no `tailscale` binary on the host itself — use
+`docker exec tailscale tailscale status`.
 
 ## Architecture
 

--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -1,6 +1,13 @@
 ---
 base_dir: /home/docker/server-docker
 
+# Tailscale subnet router. Advertises the whole home LAN so remote clients reach
+# every host, including Traefik on 192.168.0.204 via names resolved by the AdGuard
+# instance on this host. Never let tailscale_routes render empty — containerboot
+# reads an empty TS_ROUTES as "withdraw all previously advertised routes".
+tailscale_hostname: docker-subnet-router
+tailscale_routes: "192.168.0.0/24"
+
 # AdGuard Home DNS rewrites, rendered into config/adguard/AdGuardHome.yaml.j2.
 # Format matches AdGuard's own schema. `answer` may be an IP or a hostname.
 # NOTE: the three "answer: A" entries are reproduced from the live config as-is;
@@ -40,3 +47,4 @@ containers:
   # Infrastructure
   - adguard
   - cloudflare-ddns
+  - tailscale

--- a/tasks/docker/tailscale.yml
+++ b/tasks/docker/tailscale.yml
@@ -1,0 +1,114 @@
+---
+- name: TAILSCALE - Validate variables
+  ansible.builtin.assert:
+    that:
+      - TAILSCALE_AUTHKEY is defined
+      - TAILSCALE_AUTHKEY | length > 0
+      - tailscale_routes is defined
+      - tailscale_routes | length > 0
+      - tailscale_hostname is defined
+    fail_msg: TAILSCALE_AUTHKEY (vault), tailscale_routes and tailscale_hostname must be set
+
+- name: TAILSCALE - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+  loop:
+    - "{{ base_dir }}/tailscale"
+
+# Kernel-mode networking needs a TUN device present on the host before the
+# container is created, otherwise the devices: bind fails. Persist for reboots.
+- name: TAILSCALE - Load tun kernel module
+  community.general.modprobe:
+    name: tun
+    state: present
+    persistent: present
+
+# A subnet router forwards packets between tailscale0 and the LAN NIC.
+# containerboot tries to set this itself, but Docker mounts /proc/sys read-only
+# in an unprivileged container, so it would exit with "failed to enable IP
+# forwarding". Setting it on the host makes containerboot's pre-flight pass.
+# This cannot live in a container sysctls: key — Docker rejects net.* sysctls
+# when network_mode is host.
+- name: TAILSCALE - Enable IP forwarding for subnet routing
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    sysctl_file: /etc/sysctl.d/99-tailscale.conf
+    sysctl_set: true
+    reload: true
+    state: present
+
+- name: TAILSCALE - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: tailscale/tailscale:v1.98.9
+
+# network_mode: host puts tailscale0 in the host network namespace, which is what
+# makes the host itself route the advertised subnet. In bridge mode the interface
+# would live in the container namespace and the LAN would stay unreachable.
+# Docker rejects ports: alongside host networking, so tailscaled binds UDP 41641
+# and the health/metrics port directly on the host.
+- name: TAILSCALE - Create container
+  community.docker.docker_container:
+    name: tailscale
+    image: tailscale/tailscale:v1.98.9
+    restart_policy: always
+    state: started
+    pull: false
+    network_mode: host
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      - "{{ base_dir }}/tailscale:/var/lib/tailscale"
+    env:
+      # Consumed only on first login; node identity then lives in the state dir.
+      TS_AUTHKEY: "{{ TAILSCALE_AUTHKEY }}"
+      # Defaults to false, which re-runs `tailscale up --authkey` on every start
+      # and hard-fails once the key expires. true = log in only if not already.
+      TS_AUTH_ONCE: "true"
+      TS_HOSTNAME: "{{ tailscale_hostname }}"
+      TS_ROUTES: "{{ tailscale_routes }}"
+      TS_STATE_DIR: /var/lib/tailscale
+      # Defaults to true. Userspace mode cannot route a subnet.
+      TS_USERSPACE: "false"
+      # Tailnet DNS points at AdGuard on this same host, in a container this very
+      # playbook stops and restarts to write config. Accepting tailnet DNS here
+      # would make the tunnel's own resolver depend on the container it exposes.
+      TS_ACCEPT_DNS: "false"
+      TS_ENABLE_HEALTH_CHECK: "true"
+      TS_ENABLE_METRICS: "true"
+      TS_LOCAL_ADDR_PORT: "0.0.0.0:9002"
+
+# No web UI, so no homepage/proxied — same shape as gluetun. port/scheme point at
+# containerboot's health and metrics listener so Gatus and Prometheus can see the
+# state of the tunnel itself.
+- name: TAILSCALE - Define service entry
+  ansible.builtin.set_fact:
+    tailscale_entry:
+      name: tailscale
+      description: Tailnet subnet router
+      icon: tailscale
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 9002
+      scheme: http
+      secured: false
+      healthcheck: true
+      healthcheck_path: /healthz
+      metrics: true
+      metrics_port: 9002
+
+- name: TAILSCALE - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [tailscale_entry] }}"

--- a/terraform/tailscale/dns.tf
+++ b/terraform/tailscale/dns.tf
@@ -1,0 +1,31 @@
+# Split DNS silently stops working if MagicDNS is off, so pin it on rather than
+# leaving it to whatever the admin console happens to have set.
+resource "tailscale_dns_preferences" "homelab" {
+  magic_dns = true
+}
+
+# Routes only *.suskins.co.uk at AdGuard Home, which rewrites it to Traefik on
+# 192.168.0.204 — the same resolution path LAN clients get. Every other name keeps
+# using the client's normal resolver, so general DNS still works off-LAN when the
+# homelab is down.
+resource "tailscale_dns_split_nameservers" "internal" {
+  domain      = var.internal_domain
+  nameservers = [var.adguard_nameserver]
+}
+
+# ---------------------------------------------------------------------------
+# FULL OVERRIDE alternative — send ALL tailnet DNS to AdGuard, giving ad-blocking
+# on every device anywhere. Terraform can set the nameserver list, but the
+# "Override local DNS" toggle it depends on is NOT exposed by the Tailscale API or
+# this provider (tailscale/terraform-provider-tailscale#448), so it must be flipped
+# by hand — full override can never be fully IaC.
+#
+# Trade-off: an AdGuard restart then means a total DNS outage on every tailnet
+# device, and tasks/docker/adguard.yml deliberately stops the container whenever
+# its rendered config changes. Do NOT add a second nameserver as a "fallback":
+# clients spread queries across global nameservers, so ad-blocking would become
+# intermittent and internal names would resolve only some of the time.
+# ---------------------------------------------------------------------------
+# resource "tailscale_dns_nameservers" "homelab" {
+#   nameservers = [var.adguard_nameserver]
+# }

--- a/terraform/tailscale/main.tf
+++ b/terraform/tailscale/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29"
+    }
+  }
+
+  backend "s3" {
+    bucket = "homelab-terraform-state"
+    key    = "tailscale/terraform.tfstate"
+
+    # Cloudflare R2 endpoint — replace <ACCOUNT_ID> with your Cloudflare account ID
+    endpoints = {
+      s3 = "https://5f5532f14ac2515183403022a0148383.r2.cloudflarestorage.com"
+    }
+
+    region                      = "auto"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}
+
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+  tailnet             = var.tailscale_tailnet
+
+  # These must match the scopes granted to the OAuth client in the admin console,
+  # or the token exchange fails: policy_file for tailscale_acl, dns for the DNS
+  # resources, devices:core for reading tailnet devices.
+  scopes = ["devices:core", "dns", "policy_file"]
+}

--- a/terraform/tailscale/policy.tf
+++ b/terraform/tailscale/policy.tf
@@ -1,0 +1,28 @@
+# This resource owns the ENTIRE tailnet policy file. If the policy has ever been
+# hand-edited in the admin console, import it before the first apply or those edits
+# are lost:
+#   terraform import tailscale_acl.homelab acl
+resource "tailscale_acl" "homelab" {
+  acl = jsonencode({
+    tagOwners = {
+      (var.subnet_router_tag) = [var.tailscale_tag_owner]
+    }
+
+    # Auto-approves the advertised LAN route, so a rebuilt subnet router needs no
+    # admin-console click. That matters because a rebuild may well happen while
+    # you are off-LAN and depending on this route to get back in.
+    autoApprovers = {
+      routes = {
+        (var.lan_cidr) = [var.subnet_router_tag]
+      }
+    }
+
+    acls = [
+      {
+        action = "accept"
+        src    = ["autogroup:member"]
+        dst    = ["*:*"]
+      },
+    ]
+  })
+}

--- a/terraform/tailscale/variables.tf
+++ b/terraform/tailscale/variables.tf
@@ -18,6 +18,13 @@ variable "tailscale_tailnet" {
 variable "tailscale_tag_owner" {
   description = "Tailnet user allowed to own subnet_router_tag (e.g. an email, or autogroup:admin)"
   type        = string
+
+  # A missing GitHub secret arrives as an empty string rather than an error, which
+  # would otherwise write a policy file with an unusable tag owner. Fail loudly.
+  validation {
+    condition     = length(trimspace(var.tailscale_tag_owner)) > 0
+    error_message = "tailscale_tag_owner must be set (GitHub secret TAILSCALE_TAG_OWNER)."
+  }
 }
 
 variable "subnet_router_tag" {

--- a/terraform/tailscale/variables.tf
+++ b/terraform/tailscale/variables.tf
@@ -1,0 +1,49 @@
+variable "tailscale_oauth_client_id" {
+  description = "Tailscale OAuth client ID (scopes: devices:core, dns, policy_file)"
+  type        = string
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_tailnet" {
+  description = "Tailnet name; \"-\" means the default tailnet of the credential"
+  type        = string
+  default     = "-"
+}
+
+variable "tailscale_tag_owner" {
+  description = "Tailnet user allowed to own subnet_router_tag (e.g. an email, or autogroup:admin)"
+  type        = string
+}
+
+variable "subnet_router_tag" {
+  description = "ACL tag applied to the subnet router node; must match the tag on the auth key"
+  type        = string
+  default     = "tag:subnet-router"
+}
+
+variable "lan_cidr" {
+  description = "Home LAN advertised by the subnet router; must match tailscale_routes in group_vars/docker.yml"
+  type        = string
+  default     = "192.168.0.0/24"
+}
+
+variable "internal_domain" {
+  description = "Domain resolved by AdGuard Home for tailnet clients"
+  type        = string
+  default     = "suskins.co.uk"
+}
+
+# AdGuard Home's address as seen by tailnet clients. The LAN address works via the
+# advertised subnet route and keeps this root plannable before the node exists. The
+# router's own 100.x address is more robust (it needs no route acceptance) but is
+# only knowable after first registration — swap it in as a follow-up if wanted.
+variable "adguard_nameserver" {
+  description = "Nameserver tailnet clients use for internal_domain"
+  type        = string
+  default     = "192.168.0.202"
+}


### PR DESCRIPTION
## Why

Most services are LAN-only today. Cloudflare publishes only the apex plus `authelia`/`hub`/`wedding`/`www` — there is **no public wildcard** — so `grafana`, `plex`, `gatus`, `adguard-home` and the rest resolve only via AdGuard's `*.suskins.co.uk → 192.168.0.204` rewrite pointing at Traefik.

This adds a Tailscale subnet router on the `docker` host advertising `192.168.0.0/24`, and points tailnet **split DNS** for `suskins.co.uk` at the AdGuard instance on that same host. Remote clients then get identical name resolution, routing and TLS to LAN clients, with **no inbound port forwards** — Tailscale only makes outbound connections.

The `docker` host was chosen because AdGuard already lives there, so the DNS path is a single local hop rather than depending on subnet-route forwarding.

## What changed

**Ansible**
- `tasks/docker/tailscale.yml` — follows the standard 5-step container pattern, plus the host-level prerequisites subnet routing needs (`tun` module via `community.general.modprobe`, `net.ipv4.ip_forward` via `ansible.posix.sysctl`). Both collections are already used elsewhere in the repo, so no new dependency. Carrying host prereqs inside a container task file follows the precedent in `adguard.yml`, and means they only apply where the container is registered.
- `group_vars/docker.yml` — adds `tailscale_hostname`/`tailscale_routes` and registers `tailscale` in `containers` (required, or `plays/update.yml` prunes it as an unexpected container).

**Terraform** — new `terraform/tailscale/` root (own R2 state key `tailscale/terraform.tfstate`) owning the policy file and split DNS, plus `tailscale` added to all three matrices in `terraform.yml`.

**Docs** — `CLAUDE.md`, `docs/README.md`, and `config/readme/ARCHITECTURE.md.j2` (the template; `docs/ARCHITECTURE.md` is generated and untouched).

## Container settings that are easy to get wrong

Three env vars have defaults that silently break this, so they are set explicitly with comments:

- **`TS_USERSPACE: "false"`** — defaults to **true**, and userspace mode cannot route a subnet at all.
- **`TS_AUTH_ONCE: "true"`** — defaults to **false**, which re-runs `tailscale up --authkey` on *every* container start and hard-fails once the 90-day key expires, crash-looping and killing remote access. With this set, an expired key in the vault is harmless because identity lives in the state dir.
- **`TS_ACCEPT_DNS: "false"`** — tailnet DNS is AdGuard on this same host, in a container this very playbook stops to write config. The subnet router must not consume the DNS it advertises.

`network_mode: host` is required so `tailscale0` lands in the host netns; that also means the sysctl cannot be a container `sysctls:` key, since Docker rejects `net.*` sysctls under host networking. State is a bind mount, not a named volume, so `plays/clean.yml`'s volume prune can never destroy the node identity.

`autoApprovers` in the policy file auto-approves the advertised route, so a rebuilt router needs no admin-console click — which matters when a rebuild happens while you're off-LAN and depending on that route.

## No firewall change needed

Checked, because it looks like it should need one: `ufw` only runs on the `development` host (`firewall: true`), and its INPUT rules don't filter Docker-published ports — `DOCKER-USER` is empty and Docker's FORWARD jumps sit ahead of ufw's, which is why the LAN already reaches Traefik's 443 despite the Cloudflare-only rule. Subnet-routed traffic is also SNAT'd to `192.168.0.202`, an ordinary LAN source already covered by the existing `192.168.0.0/24` rules.

## Verification done here

- `ansible-lint` passes on the new task file at the **production** profile. The repo has 12 pre-existing failures, all in files this PR doesn't touch (`plays/setup.yml`, `plays/clean.yml`, `tasks/core/shell.yml`, `tasks/docker/adguard.yml`).
- `terraform fmt -check -recursive` clean across all three roots (which also confirms the new HCL parses).
- Jinja parse check on `ARCHITECTURE.md.j2`.

**Not verified here:** `terraform validate` and Ansible module option validation could not run — `registry.terraform.io` and `galaxy.ansible.com` are both blocked from this sandbox. So the Tailscale provider's resource/attribute names and the `scopes` values are from documentation, not a live plan. The PR's own `terraform plan` job is the real check.

## Before this can work — one-time setup outside the repo

1. Apply `terraform/tailscale/` **first**, so `tag:subnet-router` exists (an auth key cannot carry a tag that isn't in the policy yet).
2. Mint an auth key: **reusable, pre-approved, non-ephemeral** (ephemeral nodes are *deleted* when offline, withdrawing the route on every reboot), tagged `tag:subnet-router`. Add to the vault as `TAILSCALE_AUTHKEY`.
3. Create a Tailscale OAuth client with `devices:core`, `dns`, `policy_file` scopes; add GitHub secrets `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET`, `TAILSCALE_TAG_OWNER`. The `scopes` in `main.tf` must match what the client was granted or the token exchange fails.

⚠️ `tailscale_acl` owns the **entire** tailnet policy file. If the console copy has been hand-edited, run `terraform import tailscale_acl.homelab acl` before the first apply or those edits are lost.

## Trade-offs worth knowing before merge

- **Single point of failure**: `192.168.0.202` now carries LAN DNS *and* all remote access, so rebooting that VM takes down both.
- **SNAT collapses remote clients into one IP** for anything behind Traefik. They share one bucket in the `ratelimit` middleware and one identity in Authelia's ban tracker, so one remote user fat-fingering a password could ban all remote users. Fixing it needs `--snat-subnet-routes=false` plus a `100.64.0.0/10` firewall rule and a static route on the UniFi gateway — deliberately out of scope here.
- **Hairpinning at home**: with routes accepted while on the LAN, traffic can route through `.202` instead of going direct, and mDNS/broadcast (Chromecast, AirPlay, printer discovery) does not traverse a subnet route at all.
- **TLS is unchanged, warts and all.** Remote clients hit Traefik directly with the pre-placed certs in `{{ base_dir }}/traefik/certs/`, exactly as LAN clients do. Any hostname showing a cert warning on LAN will show the same one remotely — pre-existing, not introduced here.

## Testing after merge

On the router: `docker logs tailscale` (want "Startup complete"; a missing sysctl gives an explicit IP-forwarding error), `docker exec tailscale tailscale status`, `sysctl net.ipv4.ip_forward`.

From a phone or laptop **off-LAN** (cellular, not the LAN):
```
dig @192.168.0.202 grafana.suskins.co.uk +short   # -> 192.168.0.204 (route + AdGuard work)
dig grafana.suskins.co.uk +short                  # -> 192.168.0.204 (tailnet DNS config works)
curl -sv -o /dev/null https://grafana.suskins.co.uk
```
If the first works but the second doesn't, the fault is tailnet DNS config rather than routing. Linux clients need `tailscale up --accept-routes`; iOS/Android/macOS accept routes by default. Note there's no `tailscale` binary on the host — use `docker exec`.

**Rollback:** remove `tailscale` from `containers`; the next `plays/update.yml` prunes it, tearing down `tailscale0` and withdrawing the routes.

## Drive-by staleness spotted (not fixed here)

`CLAUDE.md:18,42`, `docs/README.md` and `config/readme/ARCHITECTURE.md.j2:36` all reference `plays/deploy-containers.yml`, which doesn't exist — container deployment happens in `plays/update.yml`. `CLAUDE.md` also says 4 host groups; there are 6. Happy to fix in a separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014LYWfmUJ1yQdNJBzHXfrb3)_