### PR TITLE
feat: add TREK travel planner container

### DIFF
--- a/config/authelia/configuration.yml.j2
+++ b/config/authelia/configuration.yml.j2
@@ -220,6 +220,26 @@ identity_providers:
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
 
+      - client_id: trek
+        client_name: TREK
+        client_secret: '{{ AUTHELIA_OIDC_TREK_SECRET }}'
+        public: false
+        authorization_policy: two_factor
+        redirect_uris:
+          - 'https://trek.{{ domain }}/auth/oidc/callback'
+        scopes:
+          - openid
+          - profile
+          - email
+          - groups
+        response_types:
+          - code
+        grant_types:
+          - authorization_code
+        access_token_signed_response_alg: none
+        userinfo_signed_response_alg: none
+        token_endpoint_auth_method: client_secret_basic
+
       - client_id: wedding-admin
         client_name: Wedding Admin
         client_secret: '{{ AUTHELIA_OIDC_WEDDING_SECRET }}'

--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -44,6 +44,7 @@ containers:
   - wedding-db
   - wedding-db-backup
   - wedding
+  - trek
   # Infrastructure
   - adguard
   - cloudflare-ddns

--- a/tasks/docker/trek.yml
+++ b/tasks/docker/trek.yml
@@ -1,0 +1,70 @@
+---
+- name: TREK - Create directory and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    recurse: true
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0750"
+  loop:
+    - "{{ base_dir }}/trek/data"
+    - "{{ base_dir }}/trek/uploads"
+
+- name: TREK - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: mauriceboe/trek:3.4.1
+
+- name: TREK - Create container
+  community.docker.docker_container:
+    name: trek
+    image: mauriceboe/trek:3.4.1
+    restart_policy: always
+    state: started
+    pull: false
+    networks:
+      - name: homelab
+    ports:
+      - "3005:3000"
+    volumes:
+      # Only /app/data and /app/uploads may be mounted — mounting /app itself
+      # shadows the bundled application and breaks the container.
+      - "{{ base_dir }}/trek/data:/app/data"
+      - "{{ base_dir }}/trek/uploads:/app/uploads"
+    env:
+      NODE_ENV: production
+      TZ: "{{ timezone }}"
+      LOG_LEVEL: info
+      APP_URL: "https://trek.{{ domain }}"
+      # At-rest key for secrets stored in the SQLite DB. Must stay stable
+      # across redeploys or previously encrypted values become unreadable.
+      ENCRYPTION_KEY: "{{ TREK_ENCRYPTION_KEY }}"
+      # One reverse proxy hop (Traefik) for X-Forwarded-For/-Proto.
+      TRUST_PROXY: "1"
+
+- name: TREK - Define service entry
+  ansible.builtin.set_fact:
+    trek_entry:
+      name: trek
+      description: Travel planner
+      # No dashboard-icons entry for TREK; fall back to a Material Design icon.
+      icon: mdi-map-marker-path
+      host: "trek.{{ domain }}"
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 3005
+      scheme: http
+      # TREK has its own login; Authelia forward-auth would double up on it.
+      secured: false
+      healthcheck: true
+      healthcheck_path: /api/health
+      homepage: true
+      proxied: true
+
+- name: TREK - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [trek_entry] }}"

--- a/tasks/docker/trek.yml
+++ b/tasks/docker/trek.yml
@@ -45,6 +45,17 @@
       ENCRYPTION_KEY: "{{ TREK_ENCRYPTION_KEY }}"
       # One reverse proxy hop (Traefik) for X-Forwarded-For/-Proto.
       TRUST_PROXY: "1"
+      # SSO against Authelia. Password auth stays enabled (OIDC_ONLY unset) so
+      # the local admin remains a way in if the OIDC round trip breaks.
+      OIDC_ISSUER: "https://authelia.{{ domain }}"
+      OIDC_CLIENT_ID: trek
+      OIDC_CLIENT_SECRET: "{{ AUTHELIA_OIDC_TREK_SECRET }}"
+      OIDC_DISPLAY_NAME: Authelia
+      # OIDC_SCOPE replaces the defaults outright, so the three standard
+      # scopes have to be repeated alongside groups.
+      OIDC_SCOPE: "openid email profile groups"
+      OIDC_ADMIN_CLAIM: groups
+      OIDC_ADMIN_VALUE: suskins_admin
 
 - name: TREK - Define service entry
   ansible.builtin.set_fact:


### PR DESCRIPTION
Adds [TREK](https://github.com/liketrek/TREK) — a self-hosted collaborative travel planner (maps, budgets, packing lists, journal) — to the `docker` host, with SSO against Authelia.

## Changes

- **`tasks/docker/trek.yml`** — new container task following the standard pattern: create data/uploads dirs → pre-pull `mauriceboe/trek:3.4.1` → create container with `pull: false` → define service entry → append to `docker_services`.
- **`group_vars/docker.yml`** — registers `trek` in the `containers` list.
- **`config/authelia/configuration.yml.j2`** — adds a confidential `trek` OIDC client.

## Configuration decisions

- **Image pinned to `3.4.1`** (latest stable; `3.5.0-pre.1` exists but is a pre-release), so Renovate tracks it like every other container. The `image:` literal is repeated in the pre-pull `vars:` and the `docker_container` task as the pattern requires.
- **Port `3005:3000`** — 3000, 3003 and 3004 are already taken on this host (homepage, pubgolf-frontend, wedding).
- **Volumes** — only `/app/data` and `/app/uploads` are mounted; upstream warns that mounting `/app` itself shadows the bundled app and breaks the container.
- **`TRUST_PROXY=1`** so X-Forwarded-For/-Proto from Traefik are honoured. `FORCE_HTTPS` is deliberately left at its default — enabling it would 301 the plain-HTTP Gatus probe and show the service as down.
- **Health check** — `healthcheck_path: /api/health`, which the image also uses for its built-in Docker HEALTHCHECK.
- **Icon** — dashboard-icons has no TREK entry, so the service entry uses the Material Design fallback `mdi-map-marker-path`.

Traefik needs no extra config: WebSocket upgrades on `/ws` (used for real-time sync) pass through transparently.

## Auth

TREK authenticates against Authelia directly rather than sitting behind forward-auth (`secured: false`) — it has its own session layer and invites collaborators to trips, so an Authelia gate in front would double up on login and get in the way of sharing. It stays LAN/tailnet-only either way: no Cloudflare record is added, so `trek.<domain>` resolves through the AdGuard wildcard to Traefik and isn't publicly reachable.

The OIDC client follows the same shape as `wedding-admin` — confidential, `two_factor` policy, `client_secret_basic` — with the callback registered at `https://trek.<domain>/auth/oidc/callback`. Two things worth flagging:

- **Admin mapping** — `OIDC_ADMIN_CLAIM=groups` / `OIDC_ADMIN_VALUE=suskins_admin`, so members of the existing admin group land in TREK as admins. That needs the `groups` scope on both sides, and `OIDC_SCOPE` replaces TREK's defaults outright, hence `openid email profile groups` spelled out in full.
- **Password auth stays on** (`OIDC_ONLY` unset) so the local admin account remains a way in if the OIDC round trip breaks. Worth flipping on once SSO is confirmed working.

`require_pkce` is omitted because TREK's PKCE support isn't documented and the provider config only enforces it for public clients. If the login round trip errors, `token_endpoint_auth_method` (`client_secret_post` vs `client_secret_basic`) is the other likely knob.

## Before deploying

Two vault entries are needed in `~/.ansible/vault.yml` — the play references both and will fail fast if either is missing:

- `TREK_ENCRYPTION_KEY` — generate with `openssl rand -hex 32`. Encrypts secrets at rest in TREK's SQLite DB, so it must stay stable across redeploys or previously stored values become unreadable.
- `AUTHELIA_OIDC_TREK_SECRET` — the OIDC client secret, consumed by both the Authelia config and TREK, matching how `AUTHELIA_OIDC_WEDDING_SECRET` and friends are handled.

On first start, TREK prints generated admin credentials to the container logs (`docker logs trek`) unless `ADMIN_EMAIL`/`ADMIN_PASSWORD` are set.

## Testing

YAML and the rendered Authelia template parse cleanly; not applied against the live host — no Ansible tooling in this environment. Verify with `ansible-playbook plays/update.yml --ask-vault-pass --limit 192.168.0.202`, then confirm the SSO button completes a round trip before considering `OIDC_ONLY`.