### PR TITLE
fix: correct TREK OIDC client registration

### DIFF
--- a/config/authelia/configuration.yml.j2
+++ b/config/authelia/configuration.yml.j2
@@ -225,6 +225,9 @@ identity_providers:
         client_secret: '{{ AUTHELIA_OIDC_TREK_SECRET }}'
         public: false
         authorization_policy: two_factor
+        # TREK always sends an S256 challenge, so enforce PKCE for this client.
+        require_pkce: true
+        pkce_challenge_method: S256
         redirect_uris:
           - 'https://trek.{{ domain }}/api/auth/oidc/login'
           # TREK's README documents /auth/oidc/callback, but the app actually
@@ -242,7 +245,9 @@ identity_providers:
           - authorization_code
         access_token_signed_response_alg: none
         userinfo_signed_response_alg: none
-        token_endpoint_auth_method: client_secret_basic
+        # TREK posts client_id/client_secret in the token request body rather
+        # than using HTTP Basic, so basic auth here fails the exchange with 401.
+        token_endpoint_auth_method: client_secret_post
 
       - client_id: wedding-admin
         client_name: Wedding Admin

--- a/config/authelia/configuration.yml.j2
+++ b/config/authelia/configuration.yml.j2
@@ -227,6 +227,9 @@ identity_providers:
         authorization_policy: two_factor
         redirect_uris:
           - 'https://trek.{{ domain }}/api/auth/oidc/login'
+          # TREK's README documents /auth/oidc/callback, but the app actually
+          # sends the /api-prefixed path — confirmed from an Authelia
+          # invalid_request rejection naming the exact redirect_uri.
           - 'https://trek.{{ domain }}/api/auth/oidc/callback'
         scopes:
           - openid


### PR DESCRIPTION
Follow-up to #137 — two corrections to the `trek` OIDC client, both from live failures.

## 1. Redirect URI

Authorization was rejected outright:

```
The 'redirect_uris' registered with OAuth 2.0 Client with id 'trek' did not match
'redirect_uri' value 'https://trek.suskins.co.uk/api/auth/oidc/callback'
```

The client was registered with `/auth/oidc/callback`, which is what TREK's README documents — the app actually sends the `/api`-prefixed path.

## 2. Token endpoint auth method

With the redirect fixed, the exchange then failed with `[OIDC] Token exchange failed: status 401`. TREK's `server/src/services/oidcService.ts` builds the token request as:

```ts
const body = new URLSearchParams({
  grant_type: 'authorization_code',
  code, redirect_uri: redirectUri, client_id: clientId, client_secret: clientSecret,
});
```

Credentials go in the body, so the client has to be registered `client_secret_post`; `client_secret_basic` makes Authelia reject it as an unauthenticated client. TREK hand-rolls its OIDC flow (no `openid-client`/`passport` dependency), which is why it doesn't negotiate the method.

Same file always generates an S256 code challenge, so `require_pkce: true` / `pkce_challenge_method: S256` is now set too — matching the `grafana` and `wedding-admin` clients. I'd left it off in #137 only because PKCE support wasn't documented.

## Changes

- **`config/authelia/configuration.yml.j2`** — `trek` client: redirect URI corrected to `/api/auth/oidc/callback`, `token_endpoint_auth_method: client_secret_post`, PKCE enforced.

## Testing

Rendered template parses and the client now matches what TREK sends on both counts, verified against upstream source and the two error messages. Not re-tested against the live IdP — needs a deploy plus `docker restart authelia`, since the play re-templates the config but doesn't recreate the container and Authelia's `watch` only covers the users database.