### PR TITLE
fix(proxmox): restore ballooning with sane floors, enable TRIM and SSD hint

### DIFF
--- a/terraform/proxmox/ai.tf
+++ b/terraform/proxmox/ai.tf
@@ -5,6 +5,7 @@ module "ai" {
   node_name       = var.proxmox_node
   cores           = 8
   memory          = 4096
+  memory_floating = 2048
   disk_size       = 128
   ip_address      = "192.168.0.206/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/bumblebee.tf
+++ b/terraform/proxmox/bumblebee.tf
@@ -5,6 +5,7 @@ module "bumblebee" {
   node_name       = var.proxmox_node
   cores           = 4
   memory          = 2048
+  memory_floating = 1024
   disk_size       = 128
   ip_address      = "192.168.0.200/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/development.tf
+++ b/terraform/proxmox/development.tf
@@ -5,6 +5,7 @@ module "development" {
   node_name       = var.proxmox_node
   cores           = 4
   memory          = 3072
+  memory_floating = 2048
   disk_size       = 64
   ip_address      = "192.168.0.204/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/docker.tf
+++ b/terraform/proxmox/docker.tf
@@ -5,6 +5,7 @@ module "docker" {
   node_name       = var.proxmox_node
   cores           = 2
   memory          = 4096
+  memory_floating = 3072
   disk_size       = 64
   ip_address      = "192.168.0.202/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/mediaserver.tf
+++ b/terraform/proxmox/mediaserver.tf
@@ -5,6 +5,7 @@ module "mediaserver" {
   node_name       = var.proxmox_node
   cores           = 4
   memory          = 8192
+  memory_floating = 4096
   disk_size       = 64
   ip_address      = "192.168.0.201/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/modules/vm/variables.tf
+++ b/terraform/proxmox/modules/vm/variables.tf
@@ -193,15 +193,15 @@ variable "memory_floating" {
 # --- Disk ---
 
 variable "disk_ssd" {
-  description = "Present the disk as an SSD to the guest"
+  description = "Present the disk as an SSD to the guest (rotational=0, so guest IO schedulers stop seek-optimising). Correct here: local-zfs is backed by a single SSD."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "disk_discard" {
-  description = "TRIM/discard handling: on or ignore"
+  description = "TRIM/discard handling: on or ignore. On passes guest fstrim down to ZFS, so freed guest blocks are released rather than held forever — this is what keeps pool free space coalescing into large contiguous runs."
   type        = string
-  default     = "ignore"
+  default     = "on"
 }
 
 variable "disk_iothread" {

--- a/terraform/proxmox/monitor.tf
+++ b/terraform/proxmox/monitor.tf
@@ -5,6 +5,7 @@ module "monitor" {
   node_name       = var.proxmox_node
   cores           = 2
   memory          = 2048
+  memory_floating = 2048
   disk_size       = 64
   ip_address      = "192.168.0.203/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/vms.tf
+++ b/terraform/proxmox/vms.tf
@@ -41,17 +41,20 @@
 #   # cpu_type            = "host"
 #   # cpu_numa            = false
 #   # cpu_flags           = []
-#   # memory_floating     = 0             # 0 = fixed RAM (default); set = memory to balloon.
-#   #                                     # Left at 0 deliberately: ballooning lets the host
-#   #                                     # reclaim guest RAM under pressure, which stalls
-#   #                                     # busy guests. Only enable if the node is short on RAM.
+#   # memory_floating     = 0             # 0 = fixed RAM (module default); below `memory`
+#   #                                     # enables ballooning down to that floor.
+#   #                                     # SET THIS on every VM here. The node has 31 GiB and
+#   #                                     # guests are committed well past that, so ballooning
+#   #                                     # is what keeps the host from running out. Pick a
+#   #                                     # floor the guest can actually work at, not an
+#   #                                     # arbitrary fraction.
 #   #
 #   # bios                = "ovmf"        # or "seabios"
 #   # machine             = "q35"         # or "pc"
 #   # tablet_device       = true
 #   #
-#   # disk_ssd            = false
-#   # disk_discard        = "ignore"      # "on" to pass TRIM to local-zfs
+#   # disk_ssd            = true          # local-zfs is a single SSD
+#   # disk_discard        = "on"          # passes guest fstrim down to ZFS
 #   # disk_iothread       = false
 #   # disk_cache          = "none"
 #   # disk_backup         = true          # include in vzdump backups


### PR DESCRIPTION
Reverts the ballooning removal from #139 and flips two module disk defaults now that the backing store is known.

## Why the revert

#139 disabled ballooning on the theory that balloon-squeezing was stalling busy guests. The host data doesn't support that, and does support the opposite:

- **No OOM kills in 14 days** — memory exhaustion has not been killing guests, so the original theory had no evidence behind it.
- **The node is genuinely oversubscribed.** 33,792 MiB of guest memory committed against **31.1 GiB** of host RAM, with zero swap.
- **The ARC is being starved.** Capped at 3.1 GiB (PVE's 10% default), forced down to 1.2 GiB, with `Available memory size` reported *negative*.

Ballooning wasn't the problem — it was the mechanism keeping the host inside its memory budget. Removing it took away the valve on a host that needs one. Nothing has OOMed yet only because QEMU allocates lazily and the guests haven't touched all their pages.

The gap came from sizing against the Terraform files alone. The node also runs guests this repo doesn't describe — `nas` (VM 100, 8192 MiB), `starscream` (VM 310, 6144 MiB, currently stopped) and `pelican-panel` (LXC 300, stopped).

## Floors

Chosen per guest rather than restored to the previous arbitrary values:

| VM | memory | floating | rationale |
|---|---|---|---|
| `mediaserver` | 8192 | 4096 | unchanged from before |
| `docker` | 4096 | **3072** | was 2048 — don't let the container host be squeezed to 2G |
| `ai` | 4096 | 2048 | |
| `development` | 3072 | 2048 | |
| `monitor` | 2048 | **2048** | pinned at full — metrics should stay stable under pressure |
| `bumblebee` | 2048 | **1024** | was 2048 — a CI runner is the cheapest thing to reclaim from |

Floor ~24.5 GiB, ceiling 33 GiB.

## Disk defaults

Two changes in `modules/vm`, applying to all VMs:

- **`disk_discard` → `"on"`** (was `"ignore"`). Guest `fstrim.timer` already runs weekly but currently does nothing, because the host discards the TRIM. Without it, blocks freed inside a guest are never released from ZFS's view and can't coalesce back into large contiguous free runs — which is what drives `FRAG` to 47% at only 50% capacity.
- **`disk_ssd` → `true`** (was `false`). `local-zfs` is backed by a single SSD, so `rotational=0` is correct and stops guest IO schedulers seek-optimising a device that doesn't seek.

Not included: `iothread`. It needs a new `scsi_hardware` variable, and the evidence for IO contention is weak compared to the nightly backup load.

## Applying

Plan should be in-place updates only, same shape as #139. **All of it takes effect on VM stop/start, not reboot** — the QEMU process has to restart.

⚠️ Do not start `starscream` (6144 MiB) or `pelican-panel` while everything else is running — that would put ~39.9 GiB against 31.1 GiB of RAM.

## Not addressed here

Host-side, outside this repo:

- `/var/lib/vz/dump` is **780G** with no `prune-backups` retention set, and `vzdump.conf` has neither `bwlimit` nor `ionice` — an unthrottled nightly backup against the single SSD every VM boots from. Currently the strongest remaining freeze hypothesis; worth checking whether freezes cluster around 02:00.
- VM 9000 (the cloud-init template) is backed up daily at ~349M despite never changing.
- `zpool set autotrim=on rpool` — off by default, worth having on an all-SSD pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JicXFU7Lmhxf65BJNDqtiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JicXFU7Lmhxf65BJNDqtiF)_