### PR TITLE
perf(mediaserver): cache CIFS attributes for 60s

### DIFF
--- a/tasks/core/base.yml
+++ b/tasks/core/base.yml
@@ -41,5 +41,10 @@
     src: //{{ nas_ip }}/media
     path: /mnt/media
     fstype: cifs
-    opts: "username=mediaserver,password={{ mediaserver_password }},uid=1000,gid=1000,rw,exec,_netdev,nofail,soft,echo_interval=15"
+    # actimeo caches file attributes for 60s instead of the CIFS default of 1s.
+    # The *arr stack and Plex stat the library constantly, and every expired
+    # entry is a round trip to a 5400rpm drive, so the default turns library
+    # scans into a seek storm. All writes go through this same mount, so the
+    # client cache stays self-consistent and new files still appear promptly.
+    opts: "username=mediaserver,password={{ mediaserver_password }},uid=1000,gid=1000,rw,exec,_netdev,nofail,soft,echo_interval=15,actimeo=60"
     state: mounted


### PR DESCRIPTION
Adds `actimeo=60` to the CIFS media mount in `tasks/core/base.yml`.

## Why

The mount currently runs with the CIFS default attribute cache of **1 second**. Plex, Sonarr, Radarr, Bazarr, Prowlarr and Profilarr all walk `/mnt/media` continuously, so nearly every `stat()` expires its cache entry and becomes an SMB round trip.

The share is backed by a single **5400rpm** drive — `ST4000VN006`, passed through to the NAS guest — so each of those round trips costs a seek. A 1-second attribute cache against spinning rust turns routine library scans into a seek storm.

`actimeo=60` holds attributes for a minute instead. Media file attributes essentially never change, so the cache is almost always valid.

## Correctness

Every writer (qbittorrent downloading, the *arr stack importing and moving) goes through this **same mount on the same host**, so the client-side attribute cache stays self-consistent. Newly imported files still appear promptly — the cache only delays visibility of changes made *outside* this client, and there aren't any.

## Applying — merging this does NOT apply it

`plays/update.yml`, which runs automatically on push to main, does not include `tasks/core/base.yml`. It covers apt, firewall, the Docker daemon config, containers, service aggregation, docs and reboots — but the mount task is only reachable through `plays/setup.yml`.

So merging changes nothing on the host until you run:

```bash
ansible-playbook plays/setup.yml --ask-vault-pass --limit mediaserver
```

That rewrites the fstab entry via `base.yml`, and because `base_results` reports changed, `setup.yml` sets `reboot_required` and reboots the host — giving a clean mount with the new options.

A plain reboot without that play would **not** work: it remounts from `/etc/fstab`, which still holds the old options until `base.yml` rewrites it. Manually remounting has the same problem, and CIFS `remount` doesn't reliably apply `actimeo` changes in any case.

Verify afterwards with `mount | grep /mnt/media` — `actimeo=60` should appear in the option list.

To roll back: revert this commit and re-run the same play.

## Deliberately not included

I'd suggested pinning `vers=3.1.1` alongside this. Dropped it on reflection:

- The kernel already negotiates 3.1.1 against TrueNAS SCALE, so it buys nothing measurable.
- If the server's max protocol were ever set lower, the mount would **fail outright** rather than negotiate down — and a failed mount blocks Docker via the `RequiresMountsFor=/mnt/media` drop-in, taking every media service down with it.

Bad risk/reward for zero upside.

## Scope

Only affects hosts with `mount_nas: true`, which is `mediaserver` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JicXFU7Lmhxf65BJNDqtiF