### PR TITLE
fix(proxmox): get guest memory under the node budget

### DIFF
--- a/terraform/proxmox/ai.tf
+++ b/terraform/proxmox/ai.tf
@@ -4,8 +4,8 @@ module "ai" {
   vm_id           = 206
   node_name       = var.proxmox_node
   cores           = 8
-  memory          = 4096
-  memory_floating = 2048
+  memory          = 2048
+  memory_floating = 1024
   disk_size       = 128
   ip_address      = "192.168.0.206/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/development.tf
+++ b/terraform/proxmox/development.tf
@@ -4,8 +4,8 @@ module "development" {
   vm_id           = 204
   node_name       = var.proxmox_node
   cores           = 4
-  memory          = 3072
-  memory_floating = 2048
+  memory          = 2048
+  memory_floating = 1024
   disk_size       = 64
   ip_address      = "192.168.0.204/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/docker.tf
+++ b/terraform/proxmox/docker.tf
@@ -5,7 +5,7 @@ module "docker" {
   node_name       = var.proxmox_node
   cores           = 2
   memory          = 4096
-  memory_floating = 3072
+  memory_floating = 4096
   disk_size       = 64
   ip_address      = "192.168.0.202/24"
   ssh_public_keys = [trimspace(file("~/.ssh/homelab.pub"))]

--- a/terraform/proxmox/mediaserver.tf
+++ b/terraform/proxmox/mediaserver.tf
@@ -4,7 +4,7 @@ module "mediaserver" {
   vm_id           = 201
   node_name       = var.proxmox_node
   cores           = 4
-  memory          = 8192
+  memory          = 6144
   memory_floating = 4096
   disk_size       = 64
   ip_address      = "192.168.0.201/24"

--- a/terraform/proxmox/vms.tf
+++ b/terraform/proxmox/vms.tf
@@ -43,11 +43,13 @@
 #   # cpu_flags           = []
 #   # memory_floating     = 0             # 0 = fixed RAM (module default); below `memory`
 #   #                                     # enables ballooning down to that floor.
-#   #                                     # SET THIS on every VM here. The node has 31 GiB and
-#   #                                     # guests are committed well past that, so ballooning
-#   #                                     # is what keeps the host from running out. Pick a
-#   #                                     # floor the guest can actually work at, not an
-#   #                                     # arbitrary fraction.
+#   #                                     # SET THIS on every VM here, and keep the sum of all
+#   #                                     # `memory` values under ~28 GiB — the node has 31 GiB
+#   #                                     # and PVE plus the ZFS ARC need the rest. Commit past
+#   #                                     # that and the balloon sits permanently inflated,
+#   #                                     # which starves the busiest guests rather than
+#   #                                     # relieving them. Pick a floor the guest can actually
+#   #                                     # work at, not an arbitrary fraction.
 #   #
 #   # bios                = "ovmf"        # or "seabios"
 #   # machine             = "q35"         # or "pc"


### PR DESCRIPTION
Addresses the `docker` / `mediaserver` crashes.

## The evidence

Both crashing guests were sitting pinned at their balloon floor:

| VM | Configured | Guest actually saw | Floor |
|---|---|---|---|
| `mediaserver` | 8192 MB | **4.0 GiB** | 4096 |
| `docker` | 4096 MB | **2.9 GiB** | 3072 |

`docker stats` corroborated it — mediaserver's containers reported a 5.316 GiB limit, the value from when `dockerd` started, versus 4.0 GiB at inspection. The balloon had been inflating underneath a running system.

Neither guest logged an OOM kill. That fits ballooning's quieter failure mode: the kernel reclaims rather than kills, thrashes in direct reclaim, and stops responding without leaving a trace. A freeze with no evidence.

## The cause is arithmetic

Ceilings summed to **33,792 MiB against 31.1 GiB** of host RAM. The balloon had no choice but to stay fully inflated, and it took memory from whichever guests were working hardest — which is exactly the two that crash. Ballooning wasn't misbehaving; it was being asked to reconcile a commitment that never fit.

## Changes

Total now **28,672 MiB**, leaving room for PVE and the ZFS ARC. Ballooning returns to being an occasional valve with ~5 GiB of range instead of a permanent tax.

| VM | memory | floating | note |
|---|---|---|---|
| `ai` | 4096 → **2048** | 2048 → 1024 | |
| `development` | 3072 → **2048** | 2048 → 1024 | |
| `mediaserver` | 8192 → **6144** | 4096 unchanged | |
| `docker` | 4096 unchanged | 3072 → **4096** | stops ballooning entirely |
| `monitor` | 2048 unchanged | 2048 unchanged | |
| `bumblebee` | 2048 unchanged | 1024 unchanged | |

The cuts are justified by actual working sets — mediaserver's containers total ~2.2 GiB, docker's ~1.3 GiB. The old ceilings reserved memory the workloads never touched while the floors starved them under pressure.

Despite the lower ceiling, **mediaserver should end up with more usable memory than it has today** — it's been running at 4.0 GiB because the balloon was fully inflated, and at 6144 on a host that fits it should sit near its full allocation.

## Swap was considered and dropped

An earlier revision of this PR added a 2 GiB swap file per guest. Removed, for four reasons:

- The swap file would live on a zvol on `rpool` — **the single SSD every VM boots from**. Paging under pressure would add IO to the most contended device in the lab.
- The rebalance leaves `docker` ~2.7 GiB and `mediaserver` ~3.5 GiB of headroom over their actual working sets. Swap would be insurance against a scenario this PR already eliminates.
- A guest deep in swap is unresponsive, which is **indistinguishable from the freeze being fixed** — it could convert a clean failure into a mysterious one.
- Shipping a proven fix alongside an unproven one costs the ability to attribute the result.

If crashes persist despite ample headroom, the right next tool is per-container memory limits (currently set on only 1 of ~40 container definitions), not swap — that stops one leaking container taking the guest down, without adding disk IO.

## Applying

Plan is in-place updates only — `0 to add, 4 to change, 0 to destroy`. Takes effect on VM **stop/start**, not reboot.

No Ansible changes, so nothing to run beyond the Terraform apply.

## Note on #139

This supersedes the reasoning there. Disabling ballooning was the wrong fix, but the underlying instinct — that the busy guests were being starved — was right. The correct fix is reducing what's committed so the balloon doesn't need to be inflated, rather than removing the mechanism that was keeping the host solvent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JicXFU7Lmhxf65BJNDqtiF