### PR TITLE
Add Prometheus scraping for Home Assistant

### DIFF
--- a/config/prometheus/config.yml.j2
+++ b/config/prometheus/config.yml.j2
@@ -15,6 +15,10 @@ scrape_configs:
       {{ k }}: ["{{ v }}"]
 {% endfor %}
 {% endif %}
+{% if group[0].metrics_bearer_token is defined %}
+    authorization:
+      credentials: "{{ group[0].metrics_bearer_token }}"
+{% endif %}
     static_configs:
 {% for svc in group %}
       - targets: ["{{ svc.ip }}:{{ svc.metrics_port | default(svc.port) }}"]

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -149,6 +149,9 @@ static_services:
     healthcheck: true
     homepage: true
     proxied: true
+    metrics: true
+    metrics_path: /api/prometheus
+    metrics_bearer_token: "{{ vault_ha_prometheus_token }}"
 
   # Games
   - name: games

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -151,7 +151,7 @@ static_services:
     proxied: true
     metrics: true
     metrics_path: /api/prometheus
-    metrics_bearer_token: "{{ vault_ha_prometheus_token }}"
+    metrics_bearer_token: "{{ HOMEASSISTANT_API_TOKEN }}"
 
   # Games
   - name: games


### PR DESCRIPTION
## Summary
- HAOS can't run Alloy like the other hosts: no Docker daemon, no cloud-init/SSH user, no Python interpreter (see `plans/homeassistant-haos-terraform.md`, which intentionally keeps it out of Ansible/inventory).
- HA ships a built-in Prometheus integration (`/api/prometheus`) that Prometheus can scrape directly, no agent required.
- That endpoint requires a bearer token, which the existing scrape-config template didn't support — added an `authorization: credentials:` block, gated on a new optional `metrics_bearer_token` field.
- Wired up the existing `homeassistant` entry in `static_services` (`group_vars/all.yml`) with `metrics: true`, `metrics_path: /api/prometheus`, and `metrics_bearer_token: "{{ HOMEASSISTANT_API_TOKEN }}"`.
- By default HA's `/api/prometheus` exports every entity in every domain, including presence/location (`device_tracker`, `person`). Restricting what's exported is an HA-config concern (its own `filter:` block), not something this repo's Ansible touches — see checklist below.

## Manual steps still required (outside this repo/Ansible)
- [ ] In HA: enable `prometheus:` in `configuration.yaml`, restart, generate a long-lived access token.
- [ ] Decide what to expose and add a matching `filter:` block to `configuration.yaml`. We only want server/host metrics (CPU, memory, disk, network, uptime of the HAOS VM), not smart-home entity data:
  - [ ] Add the built-in **System Monitor** integration in HA (Settings → Devices & Services → Add Integration → System Monitor), selecting CPU/memory/disk/network/load/uptime resources.
  - [ ] Check the actual entity IDs it creates (naming has shifted across HA versions) and scope `filter.include_entity_globs` (or `include_entities`) to just those, e.g.:
    ```yaml
    prometheus:
      filter:
        include_entity_globs:
          - sensor.system_monitor_*
    ```
- [ ] `ansible-vault edit ~/.ansible/vault.yml` and add `HOMEASSISTANT_API_TOKEN: <token>`.
- [ ] Run `ansible-playbook plays/update.yml --ask-vault-pass` to render the new scrape config and confirm the `homeassistant` target is `up` in Prometheus.

## Test plan
- [ ] Render `config/prometheus/config.yml.j2` (or run `update.yml`) and confirm the `homeassistant` job includes the `authorization` block only when `metrics_bearer_token` is set — other jobs (e.g. `gatus`) unaffected.
- [ ] Confirm Prometheus target `192.168.0.205:8123/api/prometheus` reports healthy after the token is added.
- [ ] Confirm only System Monitor metrics show up for the `homeassistant` job in Prometheus (not device_tracker/person/etc.) once the HA-side filter is applied.

https://claude.ai/code/session_011fypNAJWERmHusFJPtqdXy
