### PR TITLE
Fix cpu_temperature label and map truenas_meminfo chart

### DIFF
--- a/tasks/docker/graphite-exporter.yml
+++ b/tasks/docker/graphite-exporter.yml
@@ -260,7 +260,7 @@
         match_type: "regex"
         name: "cpu_temperature"
         labels:
-          cpu: "cpu${2}"
+          cpu: "${2}"
 
       - match: 'truenas\.(.*)\.cpu\.core_throttling\.(.*)'
         match_type: "regex"
@@ -448,6 +448,12 @@
         labels:
           type: "${2}"
           subtype: "${3}"
+
+      - match: 'truenas\.(.*)\.truenas_meminfo\.(.*)\.(.*)'
+        match_type: "regex"
+        name: "truenas_meminfo"
+        labels:
+          kind: "${2}"
 
       ################################################
       # disk by ID mapping


### PR DESCRIPTION
## Summary

Small follow-up to #147, which merged before this fix was pushed.

- `cpu_temperature`'s dimension names on this TrueNAS box already include the `cpu` prefix (`cpu0`, `cpu1`, ...), so the mapping was producing doubled labels like `cpu="cpucpu0"`. Confirmed against live output.
- Added a mapping for the `truenas_meminfo` custom chart (total/available RAM), which the upstream community mapping never covered and was falling through to graphite_exporter's auto-sanitized fallback name.

## Test plan

- [ ] Deploy via `ansible-playbook plays/deploy-containers.yml --ask-vault-pass`
- [ ] Confirm `cpu_temperature{cpu="cpu0"}` (not `cpucpu0`) and `truenas_meminfo{kind="total"}` at `http://192.168.0.203:9108/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZkDYumNpR3dugFueAkJV6