### PR TITLE
Remove stale NAS Storage Free panel from Overview dashboard

### DIFF
--- a/config/grafana/dashboards/Overview/homelab-overview.json
+++ b/config/grafana/dashboards/Overview/homelab-overview.json
@@ -98,35 +98,6 @@
       ]
     },
     {
-      "title": "NAS Storage Free",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 9 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "decimals": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "dark-red", "value": null },
-              { "color": "#EAB839", "value": 10737418240 },
-              { "color": "dark-green", "value": 53687091200 }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": { "textMode": "value", "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [
-        {
-          "expr": "min(truenas_dataset_df_complex_free)",
-          "legendFormat": "Free",
-          "refId": "A"
-        }
-      ]
-    },
-    {
       "title": "Tailscale Health Warnings",
       "type": "stat",
       "gridPos": { "h": 4, "w": 6, "x": 18, "y": 9 },


### PR DESCRIPTION
## Summary

- The "NAS Storage Free" panel on the Overview dashboard queried `truenas_dataset_df_complex_free`, a metric name from the old collectd-era TrueNAS mapping removed in #147.
- Investigated getting a real replacement (ZFS pool/dataset free space): confirmed TrueNAS's netdata build doesn't chart `/mnt/vault` despite it being a visible, readable mount with no documented exclusion rule matching it — likely a hardcoded exclusion in iXsystems' netdata build, not fixable via `netdata.conf`.
- No accurate replacement metric exists via this pipeline, so the panel is removed rather than left broken or wired to misleading data. Getting real pool capacity would need a separate poller against TrueNAS's own REST API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZkDYumNpR3dugFueAkJV6