### PR TITLE
Fix reconcile task deleting every Grafana dashboard

### DIFF
--- a/tasks/docker/grafana.yml
+++ b/tasks/docker/grafana.yml
@@ -44,11 +44,33 @@
 # `copy` never deletes, so a dashboard renamed or removed in the repo would
 # linger on the host forever and be provisioned alongside its replacement -
 # two dashboards, one stale. Reconcile the host against the repo every run.
+# `fileglob` cannot do multi-level globs like */*.json - it silently returns an
+# empty list, which made the reconcile below classify every dashboard on the
+# host as stale and delete all of them. Enumerate the repo with `find` on the
+# controller instead, and refuse to reconcile against an empty list.
+- name: GRAFANA - Find dashboards in the repo
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../config/grafana/dashboards"
+    recurse: true
+    patterns: "*.json"
+  delegate_to: localhost
+  become: false
+  changed_when: false
+  register: grafana_repo_dashboards
+
+- name: GRAFANA - Refuse to reconcile against an empty repo dashboard list
+  ansible.builtin.assert:
+    that: grafana_repo_dashboards.files | length > 0
+    fail_msg: >-
+      Found no dashboards under config/grafana/dashboards. Refusing to
+      reconcile, because that would delete every dashboard on the host.
+
 - name: GRAFANA - Find dashboards present on the host
   ansible.builtin.find:
     paths: "{{ base_dir }}/grafana/dashboards"
     recurse: true
     patterns: "*.json"
+  changed_when: false
   register: grafana_host_dashboards
 
 - name: GRAFANA - Remove dashboards no longer in the repo
@@ -60,9 +82,7 @@
        | reject('in', repo_dashboards) | list }}
   vars:
     repo_dashboards: >-
-      {{ lookup('ansible.builtin.fileglob',
-                playbook_dir ~ '/../config/grafana/dashboards/*/*.json',
-                wantlist=True)
+      {{ grafana_repo_dashboards.files | map(attribute='path')
          | map('regex_replace', '^.*/config/grafana/dashboards/',
                base_dir ~ '/grafana/dashboards/') | list }}
   loop_control:


### PR DESCRIPTION
## Urgent — restores the dashboards

The reconcile task I added in #153 **deleted all 11 dashboards from the host** on its first run. The folders (`Apps/`, `Infrastructure/`, `Monitoring/`, `Overview/`) are present but empty.

### Cause

`ansible.builtin.fileglob` does not support multi-level globs. Its documented behaviour is that patterns apply to files, not directory paths, so:

```
config/grafana/dashboards/*/*.json
```

matched nothing and returned an **empty list** rather than erroring. Then:

```
grafana_host_dashboards.files | map(attribute='path') | reject('in', [])
```

rejected nothing, so every dashboard on the host was classified as "no longer in the repo" and removed.

The copy step runs *before* the reconcile, so each play run re-copied the dashboards and then deleted them again — deterministic, and it would have repeated on every run.

### Fix

- enumerate the repo with `find` delegated to `localhost`, which handles recursion correctly
- **assert the repo list is non-empty before reconciling** — this is the guard that should have been there from the start. A reconcile that deletes must fail closed, never treat "I found nothing" as "delete everything"
- mark both `find` tasks `changed_when: false` so they stop reporting the play as changed every run

### Verified

Simulated against the real repo tree: 11 files found, host with 13 (the 11 plus the two renamed-away files) → deletes exactly `gatus-slo.json` and `monitoring-health.json`, nothing else. Guard passes with a populated repo and fails the play with an empty one.

Merging this and letting `update.yml` run restores all 11 dashboards.
