### PR TITLE
Slim Discord alert notifications to a glanceable one-liner

### DIFF
--- a/config/grafana/templates/contact-points.yml.j2
+++ b/config/grafana/templates/contact-points.yml.j2
@@ -21,16 +21,9 @@ contactPoints:
           url: {{ GRAFANA_ALERT_DISCORD_URL }}
           use_discord_username: false
           title: >-
-            {% raw %}{{ if eq .Status "firing" }}🔴 FIRING{{ if gt (len .Alerts.Firing) 1 }} ×{{ len .Alerts.Firing }}{{ end }}{{ else }}✅ RESOLVED{{ end }} · {{ .CommonLabels.alertname }}{% endraw %}
+            {% raw %}{{ if eq .Status "firing" }}🔴{{ else }}🟢 Resolved ·{{ end }} {{ .CommonLabels.alertname }}{{ if gt (len .Alerts) 1 }} ×{{ len .Alerts }}{{ end }}{% endraw %}
           message: |-
-            {% raw %}{{ range .Alerts.Firing }}{{ .Annotations.summary }}
-
-            {{ range .Labels.SortedPairs }}{{ if and (ne .Name "alertname") (ne .Name "grafana_folder") }}`{{ .Name }}: {{ .Value }}`  {{ end }}{{ end }}
-            Firing since {{ .StartsAt.Format "15:04 on 2 Jan" }}
-            [Alert]({{ .GeneratorURL }}){{ if .DashboardURL }} · [Dashboard]({{ .DashboardURL }}){{ end }}{{ if .SilenceURL }} · [Silence]({{ .SilenceURL }}){{ end }}
-
-            {{ end }}{{ range .Alerts.Resolved }}{{ .Annotations.summary }}
-            Recovered after {{ .EndsAt.Sub .StartsAt }}
-
+            {% raw %}{{ range .Alerts.Firing }}{{ $first := true }}{{ range .Labels.SortedPairs }}{{ if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") }}{{ if $first }}🔴 {{ else }} · {{ end }}{{ $first = false }}{{ .Value }}{{ end }}{{ end }}
+            {{ end }}{{ range .Alerts.Resolved }}{{ $first := true }}{{ range .Labels.SortedPairs }}{{ if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") }}{{ if $first }}🟢 {{ else }} · {{ end }}{{ $first = false }}{{ .Value }}{{ end }}{{ end }}
             {{ end }}{% endraw %}
 {% endif %}


### PR DESCRIPTION
## What

Discord alert notifications were still a wall of text (summary sentences, label pairs, timestamps, alert/silence links) — useless at a glance on a phone. This rewrites the `title`/`message` templates in `config/grafana/templates/contact-points.yml.j2` down to the essentials:

- **Title**: `🔴 <alert name>` when firing, `🟢 Resolved · <alert name>` when resolved, with `×N` appended when the group holds more than one alert. Discord already colours the embed red/green by status.
- **Message**: one line per alert instance — just the identifying label values (everything except `alertname`, `grafana_folder`, `severity`) joined with `·`, prefixed with that alert's own 🔴/🟢 so mixed firing/resolved groups stay readable. Alerts with no instance labels (e.g. backup-stale) get an empty body; the title says it all.

Example rendering:

> **🔴 Disk space low ×2**
> 🔴 games · /mnt/data
> 🔴 nas · /srv

> **🟢 Resolved · Host down (node metrics absent)**
> 🟢 mediaserver

## Verification

- Rendered the Jinja template with and without `GRAFANA_ALERT_DISCORD_URL`; both outputs parse as valid YAML and the `{% raw %}` guards keep the Go template intact.
- Executed the extracted title/message Go templates with `text/template` against mock alert payloads (single firing, multi-instance, resolved, label-less, mixed firing+resolved) — all render as shown above.
- Post-deploy: run `plays/update.yml`, then Grafana → Alerting → Contact points → discord → **Test** and check the embed in `#alerts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01To18jkYPVzT6fVLuLnithL

---
_Generated by [Claude Code](https://claude.ai/code/session_01To18jkYPVzT6fVLuLnithL)_