### PR TITLE
Post Discord alerts via a raw webhook payload

### DIFF
--- a/config/grafana/templates/contact-points.yml.j2
+++ b/config/grafana/templates/contact-points.yml.j2
@@ -1,6 +1,17 @@
-{# Grafana's notification templates use {{ }} too, so everything Grafana must
-   evaluate at alert time is wrapped in {% raw %}. Only GRAFANA_ALERT_DISCORD_URL
-   is substituted by Ansible. #}
+{# Grafana's notification templates use {{ }} too, so the whole payload block is
+   wrapped in {% raw %}. Only GRAFANA_ALERT_DISCORD_URL is substituted by Ansible.
+
+   Keep {% raw %}/{% endraw %} on lines of their own. Ansible renders with
+   trim_blocks, so a Jinja tag at the end of a line swallows the newline after it
+   and folds the following YAML key into the previous value - that is what
+   silently dropped the `message` setting and left Grafana using its default
+   (very verbose) notification template. A tag on its own line leaves one blank
+   line at the top of the block scalar below, which the leading `{{-` trims away.
+
+   Discord is wired as a `webhook` receiver rather than Grafana's `discord` one:
+   the discord receiver always builds an embed with its own colour bar, footer
+   and field list, whereas a custom webhook payload posts Discord's plain
+   `content` field, so what arrives is exactly the text below and nothing else. #}
 apiVersion: 1
 contactPoints:
   - orgId: 1
@@ -16,14 +27,39 @@ contactPoints:
     name: discord
     receivers:
       - uid: discord
-        type: discord
+        type: webhook
         settings:
           url: {{ GRAFANA_ALERT_DISCORD_URL }}
-          use_discord_username: false
-          title: >-
-            {% raw %}{{ if eq .Status "firing" }}🔴{{ else }}🟢 Resolved ·{{ end }} {{ .CommonLabels.alertname }}{{ if gt (len .Alerts) 1 }} ×{{ len .Alerts }}{{ end }}{% endraw %}
-          message: |-
-            {% raw %}{{ range .Alerts.Firing }}{{ $first := true }}{{ range .Labels.SortedPairs }}{{ if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") }}{{ if $first }}🔴 {{ else }} · {{ end }}{{ $first = false }}{{ .Value }}{{ end }}{{ end }}
-            {{ end }}{{ range .Alerts.Resolved }}{{ $first := true }}{{ range .Labels.SortedPairs }}{{ if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") }}{{ if $first }}🟢 {{ else }} · {{ end }}{{ $first = false }}{{ .Value }}{{ end }}{{ end }}
-            {{ end }}{% endraw %}
+          httpMethod: POST
+          maxAlerts: 10
+          payload:
+            template: |-
+{% raw %}
+              {{- $icon := "🟠" -}}
+              {{- if eq .CommonLabels.severity "critical" -}}{{- $icon = "🔴" -}}{{- end -}}
+              {{- $body := printf "%s **%s**" $icon .CommonLabels.alertname -}}
+              {{- if ne .Status "firing" -}}
+                {{- $body = printf "🟢 **%s** resolved" .CommonLabels.alertname -}}
+              {{- end -}}
+              {{- range .Alerts -}}
+                {{- $line := "" -}}
+                {{- range .Labels.SortedPairs -}}
+                  {{- if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") -}}
+                    {{- if eq $line "" -}}
+                      {{- $line = .Value -}}
+                    {{- else -}}
+                      {{- $line = printf "%s · %s" $line .Value -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+                {{- if ne $line "" -}}
+                  {{- if eq .Status "firing" -}}
+                    {{- $body = printf "%s\n%s %s" $body $icon $line -}}
+                  {{- else -}}
+                    {{- $body = printf "%s\n🟢 %s" $body $line -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              {{ coll.Dict "content" $body | data.ToJSON }}
+{% endraw %}
 {% endif %}


### PR DESCRIPTION
The previous attempt at slimming these notifications (#155) never took effect. Ansible renders templates with `trim_blocks`, so the `{% endraw %}` ending the `title:` line swallowed the newline after it and folded the following `message:` key into the title's folded scalar. This is what actually landed on the monitor host:

```yaml
title: >-
  {{ if eq .Status "firing" }}🔴{{ else }}...{{ end }}          message: |-
```

The `message` setting did not exist, so Grafana used `default.message` — the `Value: A=0, C=1` / `Labels:` / `Annotations:` / `Silence:` dump the change set out to remove. `{% raw %}` and `{% endraw %}` now sit on lines of their own so a tag never lands where a newline is load-bearing.

The receiver also moves from `discord` to `webhook`, pointed at the same Discord webhook URL. Grafana's discord receiver always wraps output in an embed with its own colour bar, field list and `Grafana v13.1.1` footer. A webhook custom payload posts Discord's plain `content` field, so what arrives is exactly the rendered text.

## What notifications look like

```
🔴 **Host down**              🟠 **Gatus endpoint down**      🟢 **Gatus endpoint down** resolved
🔴 bumblebee                  🟠 Games · minecraft            🟢 Games · minecraft
                              🟠 Media · sonarr
```

Severity picks the icon (🔴 critical / 🟠 warning / 🟢 resolved) and identifying label values form one line per instance.

## Verification

The Jinja was rendered with Ansible's exact settings (`trim_blocks=True`, `lstrip_blocks=False`), the YAML parsed, `payload.template` extracted, and that template executed as a real Go template against five alert shapes:

- multi-instance firing, single critical, resolved — as shown above
- **no identifying labels** (`Loki ingest stalled`) — emits the header alone rather than a dangling bullet
- **label value containing `"` and `\`** — `data.ToJSON` escapes it, so a weird container name cannot produce invalid JSON

`maxAlerts: 10` caps a group below Discord's 2000-character limit.

The settings key is `payload.template` — nested, per [the webhook config struct](https://github.com/grafana/alerting/blob/main/receivers/webhook/v1/config.go). The docs page implies a flat `payloadTemplate`, which does not exist.

## Follow-up not in this PR

`config/gatus/config.yaml.j2` has Gatus posting to Discord on its own, while Grafana's `gatus-endpoint-down` rule alerts on the same endpoints — so endpoint failures likely reach Discord twice from two different systems. Worth collapsing to one source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeACCfSmaPWtTSrgcFEhxR