### PR TITLE
Fire the Gatus endpoint alert on Gatus's own schedule

### DIFF
--- a/config/grafana/provisioning/alerting/rules.yml
+++ b/config/grafana/provisioning/alerting/rules.yml
@@ -407,15 +407,19 @@ groups:
               conditions:
                 - evaluator: { type: lt, params: [1] }
 
+      # `for: 2m` mirrors Gatus's own failure-threshold of 3 probes at a 60s
+      # interval: the group evaluates every 60s, so the alert must be failing
+      # across 3 consecutive evaluations before it fires, the same span of
+      # sustained failure Gatus requires before it notifies.
       - uid: gatus-endpoint-down
         title: Gatus endpoint down
         condition: C
-        for: 5m
+        for: 2m
         noDataState: OK
         execErrState: Error
         isPaused: false
         labels: { severity: warning }
-        annotations: { summary: "Gatus health check {{ $labels.name }} ({{ $labels.group }}) has been failing for 5 minutes" }
+        annotations: { summary: "Gatus health check {{ $labels.name }} ({{ $labels.group }}) is failing" }
         data:
           - refId: A
             relativeTimeRange: { from: 600, to: 0 }


### PR DESCRIPTION
Groundwork for retiring the Gatus Discord notifier: Grafana has to detect the same failures on the same clock first, otherwise dropping Gatus's alerts means finding out about outages several minutes later.

## Timing today

**Gatus** probes every `60s` and alerts on `failure-threshold: 3`, so it posts to Discord **2–3 minutes** after a service goes down.

**Grafana** watches the same `gatus_results_endpoint_success` metric but waited `for: 5m`. Adding a 60s Prometheus scrape, the 60s group evaluation interval and 30s of `group_wait`, its notification landed **6+ minutes** behind. Gatus always won, and the Grafana copy read as stale noise.

## Change

`for: 5m` → `for: 2m`. The `monitoring` group evaluates every `60s`, so the alert must now fail across 3 consecutive evaluations — the same span of sustained failure Gatus requires before it notifies. That puts Grafana at **2.5–4.5 minutes**, overlapping Gatus's 2–3.

The summary annotation no longer hardcodes `has been failing for 5 minutes`, a duration that had to be manually kept in sync with `for`.

## Residual gap

Prometheus scrapes Gatus at `60s` (`config/prometheus/config.yml.j2` sets that for every metrics-enabled service), so Grafana can still trail Gatus by up to one scrape interval. Closing it fully would need a per-service scrape interval override on the service entry contract — not worth it for this alert.

## Note on the follow-up

This rule reads `gatus_results_endpoint_success`, so it depends on the Gatus container continuing to run and be scraped. The follow-up should remove the `alerts:`/`alerting:` Discord blocks from `config/gatus/config.yaml.j2` and keep Gatus itself as the prober — stopping the container entirely would leave this alert with no data, and `noDataState: OK` means it would silently never fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeACCfSmaPWtTSrgcFEhxR
