### PR TITLE
Stop Gatus notifying Discord, leaving Grafana as the only alerter

### DIFF
--- a/config/gatus/config.yaml.j2
+++ b/config/gatus/config.yaml.j2
@@ -1,14 +1,10 @@
+# Gatus probes endpoints and exports the results; it deliberately does not
+# notify. Grafana's `gatus-endpoint-down` rule alerts on the
+# gatus_results_endpoint_success metric this exports, so notification lives in
+# one place instead of Gatus and Grafana both posting to Discord for the same
+# outage. `metrics: true` is therefore load-bearing - without it that rule has
+# no data, and its `noDataState: OK` means it would go quiet rather than error.
 metrics: true
-
-alerting:
-  discord:
-    webhook-url: "{{ GATUS_DISCORD_WEBHOOK | default('') }}"
-    title: "Gatus"
-    default-alert:
-      description: "Health check failed"
-      send-on-resolved: true
-      failure-threshold: 3
-      success-threshold: 2
 
 ui:
   default-sort-by: group
@@ -25,9 +21,7 @@ endpoints:
     group: {{ svc.friendly_name }}
     conditions:
       - "[STATUS] == 200"
-    alerts:
-      - type: discord
-{% if svc.scheme == 'https' %}      
+{% if svc.scheme == 'https' %}
     client:
       insecure: true
 {% endif %}


### PR DESCRIPTION
Gatus and Grafana both watched every health-checked endpoint and both posted to Discord, so a single outage arrived twice from two systems, in two formats, on two different thresholds. That minecraft/sonarr alert was almost certainly duplicated. Now that #157 makes the Grafana rule fire on Gatus's own schedule, Gatus's copy is redundant.

## Change

Removes the `alerting:` block and the per-endpoint `alerts:` entries. Gatus keeps probing on the same `60s` interval, keeps its dashboard, and keeps exporting `gatus_results_endpoint_success` — only the notification path is gone.

`metrics: true` is now load-bearing rather than incidental, so the file says so: Grafana's `gatus-endpoint-down` rule reads that metric, and its `noDataState: OK` means losing it would make endpoint alerting go quiet rather than error.

Also drops trailing whitespace from the `{% if svc.scheme == 'https' %}` line. It suppressed Jinja's `trim_blocks` and emitted a stray blank line into every rendered endpoint list — the same class of bug as #156, harmless here but worth not leaving around.

## Verification

Rendered the template with Ansible's Jinja settings against a fixture covering an http endpoint, an https endpoint with a `healthcheck_path`, and a service with `healthcheck` unset, then parsed the result:

- no `alerting` key at the document root, no `alerts` key on any endpoint
- only the two health-checked services produce endpoints
- `client: {insecure: true}` still attaches to the https endpoint and only that one

```yaml
endpoints:
  - name: sonarr
    url: "http://192.168.0.201:8989"
    interval: 60s
    group: Media
    conditions:
      - "[STATUS] == 200"
  - name: minecraft
    url: "https://192.168.0.202:25565/health"
    interval: 60s
    group: Games
    conditions:
      - "[STATUS] == 200"
    client:
      insecure: true
```

No restart task is needed — [Gatus reloads its config file on the fly](https://github.com/TwiN/gatus#reloading-configuration-on-the-fly). Worth knowing that it exits on an *invalid* config update, and the container is `restart_policy: always`, so a malformed render would crashloop; that is why the render above was validated rather than eyeballed.

## Merge order

Land after #157. Merging this first leaves a window where nothing alerts for the first ~6 minutes of an outage.

`GATUS_DISCORD_WEBHOOK` in `vault.yml` now has no references anywhere in the repo and can be dropped next time the vault is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeACCfSmaPWtTSrgcFEhxR
