### PR TITLE
Escape template variables so Grafana stops eating them

### DIFF
--- a/config/grafana/templates/contact-points.yml.j2
+++ b/config/grafana/templates/contact-points.yml.j2
@@ -11,7 +11,15 @@
    Discord is wired as a `webhook` receiver rather than Grafana's `discord` one:
    the discord receiver always builds an embed with its own colour bar, footer
    and field list, whereas a custom webhook payload posts Discord's plain
-   `content` field, so what arrives is exactly the text below and nothing else. #}
+   `content` field, so what arrives is exactly the text below and nothing else.
+
+   Every Go template variable below is written `$$name`, not `$name`. Grafana
+   interpolates environment variables into provisioning files before parsing
+   them, so a bare `$icon` is expanded to the empty string - it reaches the
+   template engine as `{{- := "..." -}}` and the contact point fails at delivery
+   with `unexpected ":=" in command`. `$$` is Grafana's escape for a literal
+   dollar and is consumed during that interpolation, so the stored template holds
+   the single `$` the Go template needs. #}
 apiVersion: 1
 contactPoints:
   - orgId: 1
@@ -35,31 +43,31 @@ contactPoints:
           payload:
             template: |-
 {% raw %}
-              {{- $icon := "🟠" -}}
-              {{- if eq .CommonLabels.severity "critical" -}}{{- $icon = "🔴" -}}{{- end -}}
-              {{- $body := printf "%s **%s**" $icon .CommonLabels.alertname -}}
+              {{- $$icon := "🟠" -}}
+              {{- if eq .CommonLabels.severity "critical" -}}{{- $$icon = "🔴" -}}{{- end -}}
+              {{- $$body := printf "%s **%s**" $$icon .CommonLabels.alertname -}}
               {{- if ne .Status "firing" -}}
-                {{- $body = printf "🟢 **%s** resolved" .CommonLabels.alertname -}}
+                {{- $$body = printf "🟢 **%s** resolved" .CommonLabels.alertname -}}
               {{- end -}}
               {{- range .Alerts -}}
-                {{- $line := "" -}}
+                {{- $$line := "" -}}
                 {{- range .Labels.SortedPairs -}}
                   {{- if and (ne .Name "alertname") (ne .Name "grafana_folder") (ne .Name "severity") -}}
-                    {{- if eq $line "" -}}
-                      {{- $line = .Value -}}
+                    {{- if eq $$line "" -}}
+                      {{- $$line = .Value -}}
                     {{- else -}}
-                      {{- $line = printf "%s · %s" $line .Value -}}
+                      {{- $$line = printf "%s · %s" $$line .Value -}}
                     {{- end -}}
                   {{- end -}}
                 {{- end -}}
-                {{- if ne $line "" -}}
+                {{- if ne $$line "" -}}
                   {{- if eq .Status "firing" -}}
-                    {{- $body = printf "%s\n%s %s" $body $icon $line -}}
+                    {{- $$body = printf "%s\n%s %s" $$body $$icon $$line -}}
                   {{- else -}}
-                    {{- $body = printf "%s\n🟢 %s" $body $line -}}
+                    {{- $$body = printf "%s\n🟢 %s" $$body $$line -}}
                   {{- end -}}
                 {{- end -}}
               {{- end -}}
-              {{ coll.Dict "content" $body | data.ToJSON }}
+              {{ coll.Dict "content" $$body | data.ToJSON }}
 {% endraw %}
 {% endif %}


### PR DESCRIPTION
The webhook contact point from #156 fails every delivery:

> Last delivery attempt failed — `template: :2: unexpected ":=" in command`

## What is happening

The file on disk is correct. **Grafana interpolates environment variables into provisioning files before parsing them**, so `$icon`, `$body` and `$line` were expanded to the empty string on the way into the database.

Reading the contact point back out of `grafana.db` shows what Grafana actually stored:

```
on disk   {{- $icon := "🟠" -}}          906 chars
stored    {{-  := "🟠" -}}               811 chars
```

95 characters of variable names gone, and a template that cannot parse — line 2 is now a declaration with nothing to declare.

## Fix

Write every Go template variable as `$$name`. Per [the provisioning docs](https://grafana.com/docs/grafana/latest/administration/provisioning/), `$$` is Grafana's escape for a literal dollar; it is consumed during interpolation, so the stored template holds the single `$` the engine needs.

This also explains why the template in #155 never worked even setting aside the `trim_blocks` bug — it used `{{ $first := true }}`, which would have been eaten the same way.

## Verification

The render test now models the interpolation pass instead of stopping at the YAML, and asserts each variable survives it. Against the previous revision it fails:

```
AssertionError: $icon was eaten by env interpolation
```

Feeding that interpolated output to the **real `grafana/alerting` engine** reproduces the production error exactly:

```
broken line 2: '{{-  := "🟠" -}}'
TEMPLATE ERROR: template: :2: unexpected ":=" in command
```

And the fixed template, through the same engine, renders:

```json
{"content":"🟠 **Gatus endpoint down**\n🟠 Games · minecraft\n🟠 Media · sonarr"}
```

The interpolated length is 906, matching the on-disk length of the previously working-looking file — the escaping adds exactly the 19 characters interpolation removes.

## Note

My earlier check used plain `text/template`, which parses `$icon := ...` happily and so proved nothing about this failure. The harness now runs the actual library on the actual post-interpolation text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeACCfSmaPWtTSrgcFEhxR
