### PR TITLE
Deploy the e-ink Render Service on the docker host

### DIFF
--- a/group_vars/docker.yml
+++ b/group_vars/docker.yml
@@ -33,6 +33,7 @@ special_containers:
 
 containers:
   # Apps
+  - display
   - family-hub
   # - marginalia-postgres
   # - marginalia-api

--- a/tasks/docker/display.yml
+++ b/tasks/docker/display.yml
@@ -46,7 +46,8 @@
       scheme: http
       secured: false
       healthcheck: true
-      healthcheck_path: /health
+      # /healthz is the one route ahead of the bearer check, so Gatus needs no token.
+      healthcheck_path: /healthz
       homepage: true
       proxied: true
 

--- a/tasks/docker/display.yml
+++ b/tasks/docker/display.yml
@@ -1,0 +1,55 @@
+---
+- name: DISPLAY - Pre-pull image
+  community.docker.docker_image:
+    name: "{{ image }}"
+    source: pull
+    force_source: true
+  vars:
+    image: ghcr.io/bensuskins/display:latest
+
+- name: DISPLAY - Create container
+  community.docker.docker_container:
+    name: display
+    image: ghcr.io/bensuskins/display:latest
+    restart_policy: always
+    state: started
+    pull: false
+    networks:
+      - name: homelab
+    ports:
+      # 8080 on this host already belongs to pubgolf-backend.
+      - "8085:8080"
+    env:
+      # Shared bearer the e-ink Device presents on GET /frame. The Device
+      # fetches over the LAN at {{ inventory_hostname }}:8085, not through
+      # Traefik, so this is the only thing standing in front of /frame.
+      DEVICE_TOKEN: "{{ DISPLAY_DEVICE_TOKEN }}"
+      DARWIN_ACCESS_TOKEN: "{{ DISPLAY_DARWIN_ACCESS_TOKEN }}"
+      HUXLEY_BASE_URL: https://huxley2.azurewebsites.net
+      STATION_ORIGIN: KEL
+      STATION_DESTINATION: LST
+      DEPARTURE_MIN_LEAD_MINUTES: "15"
+      # The Render Service owns BST, so this is pinned rather than {{ timezone }}.
+      TZ: Europe/London
+
+- name: DISPLAY - Define service entry
+  ansible.builtin.set_fact:
+    display_entry:
+      name: display
+      description: E-ink panel render service
+      # No dashboard-icons entry for this; fall back to Material Design.
+      icon: mdi-monitor-dashboard
+      host: "display.{{ domain }}"
+      ip: "{{ inventory_hostname }}"
+      friendly_name: "{{ friendly_name }}"
+      port: 8085
+      scheme: http
+      secured: false
+      healthcheck: true
+      healthcheck_path: /health
+      homepage: true
+      proxied: true
+
+- name: DISPLAY - Append to docker_services
+  ansible.builtin.set_fact:
+    docker_services: "{{ docker_services + [display_entry] }}"


### PR DESCRIPTION
Adds `tasks/docker/display.yml` for [BenSuskins/display](https://github.com/BenSuskins/display)'s Render Service and registers it on the docker host.

- Standard container pattern: pre-pull → `pull: false` container → service entry → append to `docker_services`.
- Host port **8085**, container port 8080 (`ENV PORT=8080` in the app's Dockerfile) — `pubgolf-backend` already binds 8080 on this host.
- Env mirrors the app's compose file. `DEVICE_TOKEN` and `DARWIN_ACCESS_TOKEN` are the only two variables `config.ts` treats as required; the rest are set explicitly to the same values the app defaults to. `TZ` is pinned to `Europe/London` rather than `{{ timezone }}` because the Render Service owns BST.
- Gatus checks `/healthz`, the one route ahead of the bearer check, so no token is needed.
- Proxied via Traefik, unsecured, on Homepage. No Cloudflare record, so `display.suskins.co.uk` is LAN/tailnet-only via the AdGuard wildcard — same as trek.

The Device fetches `http://192.168.0.202:8085/frame?battery=<volts>` with `Authorization: Bearer <DEVICE_TOKEN>` directly over the LAN, not through Traefik, so `DEVICE_TOKEN` is the only thing in front of `/frame`.

## Pre-merge checks

- [x] `DISPLAY_DEVICE_TOKEN` and `DISPLAY_DARWIN_ACCESS_TOKEN` added to `vault.yml`.
- [x] `ghcr.io/bensuskins/display:latest` published — Render Service CI green, and an anonymous GHCR pull returns 200, so the docker host needs no registry login.
- [x] Health route verified as `/healthz` against `server/src/server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm6LdmkjTdr55PLNSweLFw