### PR TITLE
Add a macOS menu bar app for homelab CI/CD

### DIFF
--- a/.github/workflows/build-mcp-arr.yml
+++ b/.github/workflows/build-mcp-arr.yml
@@ -3,6 +3,8 @@ name: Build MCP servers
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'apps/**'
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -3,6 +3,10 @@ name: Clean Homelab
 on:
   workflow_dispatch:
 
+concurrency:
+  group: clean-homelab
+  cancel-in-progress: false
+
 jobs:
   clean:
     runs-on: self-hosted

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,6 +10,10 @@ on:
       - 'terraform/**'
   workflow_dispatch:
 
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,6 +3,8 @@ name: Update Homelab
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'apps/**'
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,9 @@ terraform/**/*.tfvars
 terraform/**/crash.log
 terraform/**/tfplan
 
+# Swift / SwiftPM (apps/homelab-menubar)
+apps/**/.build/
+apps/**/.swiftpm/
+apps/**/Package.resolved
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode,ansible,ssh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,14 @@ Host identification is governed by `docs/adr/0001-host-label-canonical-for-dashb
 
 Renovate monitors `tasks/docker/*.yml` for Docker image versions and creates PRs for updates. Images are pinned to specific versions (not `latest`).
 
+### Menu Bar App (`apps/homelab-menubar/`)
+
+A native macOS SwiftUI menu bar app that shows the state of the three dispatchable workflows, triggers/cancels them, lists and squash-merges open PRs, and links to Homepage. It is a Swift package — `make test`, `make bundle`, `make install`; see `apps/homelab-menubar/README.md`.
+
+It authenticates by shelling out to `gh`, so it holds no token. All GitHub access goes through the `CommandRunner` protocol, which is the only seam tests fake.
+
+**`update.yml` and `build-mcp-arr.yml` carry `paths-ignore: ['apps/**']`.** Both trigger on every push to `main`; without those blocks a commit touching only Swift code runs Ansible against all six hosts. Do not remove them. See `docs/adr/0003-menu-bar-app-lives-in-this-repo.md`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,3 +82,25 @@ _Avoid_: Terraform module, stack
 **Subnet Router**:
 The Tailscale node running on the `docker` host that advertises the home LAN CIDR (`192.168.0.0/24`) to the tailnet, so any tailnet device can reach homelab services without inbound port forwarding.
 _Avoid_: VPN gateway, relay
+
+### Menu Bar App
+
+**Dispatchable Workflow**:
+One of the three workflows the menu bar app is allowed to start on demand — `update.yml`, `terraform.yml`, `clean.yml`. The repository holds other workflows (`build-mcp-arr.yml`); a workflow is Dispatchable only if starting it by hand is a thing you'd deliberately do. Distinct from merely carrying a `workflow_dispatch` trigger.
+_Avoid_: job, action, pipeline
+
+**Run Row**:
+One line of the menu describing the most recent run of a Dispatchable Workflow on `main`, together with whether it can currently be triggered or cancelled. A Run Row is always present for all three workflows even when one has never run, so rows never appear or disappear between refreshes.
+_Avoid_: workflow row, status row
+
+**Glyph State**:
+What the menu bar icon shows while the menu is closed, collapsed from every Run Row to the worst thing any of them is doing: `failed` beats `running` beats `ok`. It answers one question — "do I need to open this?" — and deliberately does not distinguish which workflow is responsible. A run Awaiting Approval does not raise it.
+_Avoid_: icon state, badge
+
+**Awaiting Approval**:
+A run that has reached an environment gate with required reviewers and stopped. Terraform does this on every run, between plan and apply. It is not running (nothing is executing) and not finished (no conclusion), but it still owns the workflow, so triggering another would race it.
+_Avoid_: pending, blocked, waiting (ambiguous with queued)
+
+**Menu Snapshot**:
+The immutable value describing everything the menu renders at one moment. Produced from fetched data, consumed by the view, and cached to disk verbatim so the menu paints instantly at launch. Every question the view can ask is answered on the Snapshot, so the view holds no logic.
+_Avoid_: view model, menu state

--- a/apps/homelab-menubar/Makefile
+++ b/apps/homelab-menubar/Makefile
@@ -1,0 +1,39 @@
+APP_NAME    := Homelab
+BUNDLE      := $(APP_NAME).app
+BUILD_DIR   := .build/release
+STAGE_DIR   := .build/$(BUNDLE)
+INSTALL_DIR := /Applications
+
+.PHONY: all test build bundle install clean run
+
+all: bundle
+
+test:
+	swift test
+
+build:
+	swift build -c release --product HomelabMenuBar
+
+# SwiftPM emits a bare executable; MenuBarExtra needs a real bundle so that
+# LSUIElement is honoured and the app has no Dock icon.
+bundle: build
+	rm -rf "$(STAGE_DIR)"
+	mkdir -p "$(STAGE_DIR)/Contents/MacOS"
+	mkdir -p "$(STAGE_DIR)/Contents/Resources"
+	cp "$(BUILD_DIR)/HomelabMenuBar" "$(STAGE_DIR)/Contents/MacOS/HomelabMenuBar"
+	cp Resources/Info.plist "$(STAGE_DIR)/Contents/Info.plist"
+	codesign --force --deep --sign - "$(STAGE_DIR)"
+	@echo "Built $(STAGE_DIR)"
+
+install: bundle
+	rm -rf "$(INSTALL_DIR)/$(BUNDLE)"
+	cp -R "$(STAGE_DIR)" "$(INSTALL_DIR)/$(BUNDLE)"
+	@echo "Installed $(INSTALL_DIR)/$(BUNDLE)"
+	@echo "Launch it with: open '$(INSTALL_DIR)/$(BUNDLE)'"
+
+run: bundle
+	open "$(STAGE_DIR)"
+
+clean:
+	swift package clean
+	rm -rf .build

--- a/apps/homelab-menubar/Package.swift
+++ b/apps/homelab-menubar/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "HomelabMenuBar",
+    platforms: [.macOS(.v15)],
+    targets: [
+        .target(
+            name: "HomelabMenuBarCore",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .executableTarget(
+            name: "HomelabMenuBar",
+            dependencies: ["HomelabMenuBarCore"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "HomelabMenuBarCoreTests",
+            dependencies: ["HomelabMenuBarCore"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+    ]
+)

--- a/apps/homelab-menubar/README.md
+++ b/apps/homelab-menubar/README.md
@@ -1,0 +1,91 @@
+# Homelab Menu Bar
+
+A macOS menu bar app for this repository: see the state of the three
+dispatchable workflows, start or cancel them, see and squash-merge open pull
+requests, and jump to Homepage / Actions / the repo.
+
+```
+⚙  ← glyph: worst-of (⚠ failed > ◐ running > ⚙ ok)
+┌──────────────────────────────┐
+│ Update      ✓ passed · 2h ago│  [▶]
+│ Terraform   ⏸ awaiting appr… │
+│ Clean       ◐ running · 3m 12s  [■]
+│ ──────────────────────────── │
+│ Open PRs (1)                 │
+│  #141 chore(deps): ansible…  │  [Merge]
+│ ──────────────────────────── │
+│ Homepage ↗  Actions ↗  Repo ↗│
+└──────────────────────────────┘
+```
+
+## Requirements
+
+The [GitHub CLI](https://cli.github.com), authenticated:
+
+```bash
+gh auth status   # needs the `repo` scope
+```
+
+The app holds no token of its own — every call shells out to `gh`, so
+`gh auth login` is the only credential management there is. It searches `PATH`
+and then Nix, Homebrew and `/usr/local` explicitly, because a GUI app launched
+from Finder does not inherit your shell's `PATH`.
+
+## Build
+
+```bash
+make test      # unit tests against a fake `gh`
+make bundle    # .build/Homelab.app
+make install   # copy to /Applications
+make run       # build and launch without installing
+```
+
+`swift test` alone is the fast red/green loop. The contract tests are excluded
+from it by name:
+
+```bash
+swift test --skip Contract    # fakes only, no network
+swift test --filter Contract  # real `gh`, read-only
+```
+
+To launch at login, add `/Applications/Homelab.app` under
+System Settings → General → Login Items.
+
+## Design
+
+Data flows one way, and every layer above the process boundary is a pure
+function of the layer below:
+
+```
+GitHubCommandLineRunner   ← the only impure thing; spawns `gh`
+      ↓ Data
+GitHubClient              ← decodes, maps onto domain types
+      ↓ WorkflowRunSummary / PullRequestSummary
+AppState                  ← @Observable, owns the polling loop
+      ↓ MenuSnapshot      ← immutable; also what gets cached to disk
+MenuView
+```
+
+`MenuSnapshot` is the seam. It answers every question the view can ask — what
+colour a row is, whether its button is enabled, what the subtitle says — so the
+view holds no logic and the logic needs no view to test.
+
+Tests fake `CommandRunner`, the process boundary, which means decoding, mapping
+and snapshot construction all run for real. A handful of read-only contract
+tests run the actual `gh` to catch the one thing a fake cannot: `gh` changing
+its output.
+
+### Deliberate choices
+
+- **No confirmation on trigger.** The guard against a stray double-click is that
+  `▶` is disabled while a run is open, backed by `concurrency` groups on the
+  workflows and `use_lockfile` on the Terraform backends.
+- **The app never approves a deployment.** Terraform parks at its
+  `required_reviewers` gate; the row says so and links to the run, where the
+  plan is. Approving a plan you cannot see is just a slower auto-apply.
+- **Notify on failure only.** Success is expected and the glyph already reports
+  it, so a notification always means something broke.
+- **A run awaiting approval does not raise the glyph or tighten polling.** It
+  will sit there until a human acts.
+- **Squash merge, always.** One commit on `main` per PR is one Update Homelab
+  run is one line in the deploy log. Merging here deploys.

--- a/apps/homelab-menubar/Resources/Info.plist
+++ b/apps/homelab-menubar/Resources/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>HomelabMenuBar</string>
+	<key>CFBundleIdentifier</key>
+	<string>co.uk.suskins.HomelabMenuBar</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Homelab</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>15.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Ben Suskins</string>
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/homelab-menubar/Sources/HomelabMenuBar/HomelabMenuBarApp.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBar/HomelabMenuBarApp.swift
@@ -1,0 +1,25 @@
+import HomelabMenuBarCore
+import SwiftUI
+
+@main
+struct HomelabMenuBarApp: App {
+    @State private var state = AppState(client: GitHubClient(runner: GitHubCommandLineRunner()))
+
+    var body: some Scene {
+        MenuBarExtra {
+            MenuView()
+                .environment(state)
+        } label: {
+            Image(systemName: state.snapshot.glyph.symbolName)
+                .symbolRenderingMode(state.snapshot.glyph == .failed ? .multicolor : .monochrome)
+        }
+        .menuBarExtraStyle(.window)
+        .onChange(of: scenePhaseHasStarted, initial: true) { _, _ in
+            state.start()
+        }
+    }
+
+    /// `MenuBarExtra` has no scene phase of its own; this exists purely to give
+    /// `onChange(initial:)` something to fire against exactly once at launch.
+    private var scenePhaseHasStarted: Bool { true }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState+Actions.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState+Actions.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// The two writes that target a workflow. Modelling them as data rather than as
+/// closures keeps the typed-throws signature on `perform` unambiguous.
+private enum WorkflowWrite {
+    case dispatch
+    case cancel(runIdentifier: Int)
+}
+
+extension AppState {
+    /// Triggers fire immediately — no confirmation. The guard against a stray
+    /// double-click is that the button is disabled while a run is open, backed
+    /// by concurrency groups on the workflows themselves.
+    public func trigger(_ workflow: DispatchableWorkflow) async {
+        guard canTrigger(workflow) else { return }
+        await perform(.dispatch, on: workflow)
+    }
+
+    public func cancel(_ workflow: DispatchableWorkflow) async {
+        guard canCancel(workflow), let identifier = snapshot.row(for: workflow)?.run?.identifier
+        else { return }
+        await perform(.cancel(runIdentifier: identifier), on: workflow)
+    }
+
+    /// Squash, always: one commit on `main` per pull request, which is one
+    /// Update Homelab run, which is one line in the deploy log.
+    public func merge(_ pullRequest: PullRequestSummary) async {
+        guard pullRequest.canMerge, !busyPullRequests.contains(pullRequest.number) else { return }
+
+        markBusy(pullRequest: pullRequest.number, true)
+        defer { markBusy(pullRequest: pullRequest.number, false) }
+
+        do {
+            try await client.squashMerge(pullRequestNumber: pullRequest.number)
+        } catch {
+            setErrorMessage(error.displayMessage)
+            return
+        }
+        // The merge pushes to main, which starts Update Homelab — refresh so the
+        // run appears, and re-pace the loop now that something is active.
+        await refresh()
+        restartPolling()
+    }
+
+    private func perform(_ write: WorkflowWrite, on workflow: DispatchableWorkflow) async {
+        markBusy(workflow: workflow, true)
+        defer { markBusy(workflow: workflow, false) }
+
+        do {
+            switch write {
+            case .dispatch:
+                try await client.dispatch(workflow)
+            case .cancel(let runIdentifier):
+                try await client.cancelRun(identifier: runIdentifier)
+            }
+        } catch {
+            setErrorMessage(error.displayMessage)
+            return
+        }
+
+        await refresh()
+        restartPolling()
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState+Refresh.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState+Refresh.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+extension AppState {
+    public func start() {
+        Task { await notifier.requestAuthorization() }
+        restartPolling()
+    }
+
+    public func stop() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    /// One loop that re-reads its own interval after every pass, so a dispatch
+    /// that starts a run tightens the cadence without a second timer.
+    func restartPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.refresh()
+                let interval = PollingSchedule.interval(for: self.snapshot)
+                try? await Task.sleep(for: interval)
+            }
+        }
+    }
+
+    public func refresh() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        do {
+            let runs = try await fetchLatestRuns()
+            let pullRequests = try await client.openPullRequests()
+            apply(
+                MenuSnapshot.make(
+                    runs: runs,
+                    pullRequests: pullRequests,
+                    lastRefreshedAt: Date()
+                )
+            )
+        } catch {
+            // Keep the last good data on screen; a failed poll is not a reason
+            // to blank the menu.
+            var degraded = snapshot
+            degraded.errorMessage = error.displayMessage
+            snapshot = degraded
+        }
+    }
+
+    private func fetchLatestRuns() async throws(GitHubFailure) -> [DispatchableWorkflow: WorkflowRunSummary] {
+        var runs: [DispatchableWorkflow: WorkflowRunSummary] = [:]
+        for workflow in DispatchableWorkflow.allCases {
+            if let run = try await client.latestRun(for: workflow) {
+                runs[workflow] = run
+            }
+        }
+        return runs
+    }
+
+    private func apply(_ fresh: MenuSnapshot) {
+        let failures = FailureDetector.newFailures(previous: snapshot, current: fresh)
+        snapshot = fresh
+        cache.save(fresh)
+
+        for failure in failures {
+            Task { [notifier] in await notifier.notify(failure) }
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/App/AppState.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+public final class AppState {
+    public internal(set) var snapshot: MenuSnapshot
+    public internal(set) var isRefreshing = false
+    /// Workflows and pull requests with an in-flight write, so their button can
+    /// show a spinner and refuse a second click before the next poll lands.
+    public internal(set) var busyWorkflows: Set<DispatchableWorkflow> = []
+    public internal(set) var busyPullRequests: Set<Int> = []
+
+    public let repository: RepositoryReference
+
+    let client: GitHubClient
+    let cache: SnapshotCache
+    let notifier: any FailureNotifying
+    var pollingTask: Task<Void, Never>?
+
+    public init(
+        client: GitHubClient,
+        repository: RepositoryReference = .homelab,
+        cache: SnapshotCache = SnapshotCache(),
+        notifier: any FailureNotifying = FailureNotifier()
+    ) {
+        self.client = client
+        self.repository = repository
+        self.cache = cache
+        self.notifier = notifier
+        self.snapshot = cache.load() ?? .placeholder
+    }
+
+    public var quickLinks: [QuickLink] {
+        QuickLink.standard(for: repository)
+    }
+
+    public func canTrigger(_ workflow: DispatchableWorkflow) -> Bool {
+        guard !busyWorkflows.contains(workflow) else { return false }
+        return snapshot.row(for: workflow)?.canTrigger ?? false
+    }
+
+    public func canCancel(_ workflow: DispatchableWorkflow) -> Bool {
+        guard !busyWorkflows.contains(workflow) else { return false }
+        return snapshot.row(for: workflow)?.canCancel ?? false
+    }
+
+    public func isBusy(pullRequest number: Int) -> Bool {
+        busyPullRequests.contains(number)
+    }
+
+    func markBusy(workflow: DispatchableWorkflow, _ busy: Bool) {
+        if busy {
+            busyWorkflows.insert(workflow)
+        } else {
+            busyWorkflows.remove(workflow)
+        }
+    }
+
+    func markBusy(pullRequest number: Int, _ busy: Bool) {
+        if busy {
+            busyPullRequests.insert(number)
+        } else {
+            busyPullRequests.remove(number)
+        }
+    }
+
+    func setErrorMessage(_ message: String?) {
+        var updated = snapshot
+        updated.errorMessage = message
+        snapshot = updated
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/DispatchableWorkflow.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/DispatchableWorkflow.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A workflow this app is allowed to start. The repository holds other
+/// workflows; only the three that exist to be run on demand appear here.
+public enum DispatchableWorkflow: String, CaseIterable, Sendable, Codable, Identifiable {
+    case update = "update.yml"
+    case terraform = "terraform.yml"
+    case clean = "clean.yml"
+
+    public var id: String { rawValue }
+    public var fileName: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .update: "Update"
+        case .terraform: "Terraform"
+        case .clean: "Clean"
+        }
+    }
+
+    public var summary: String {
+        switch self {
+        case .update: "Ansible across all hosts"
+        case .terraform: "Plan and apply all three roots"
+        case .clean: "Prune Docker and system files"
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/GlyphState.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/GlyphState.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// What the menu bar icon shows when the menu is closed. It answers exactly one
+/// question — "do I need to open this?" — so the three run rows collapse into
+/// the worst thing any of them is doing.
+public enum GlyphState: String, Equatable, Sendable, Codable {
+    case ok
+    case running
+    case failed
+
+    public static func worstOf(_ statuses: [RunStatus]) -> GlyphState {
+        if statuses.contains(.failed) { return .failed }
+        if statuses.contains(where: \.isActive) { return .running }
+        return .ok
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .ok: "server.rack"
+        case .running: "arrow.trianglehead.2.clockwise.rotate.90"
+        case .failed: "exclamationmark.triangle.fill"
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/RepositoryReference.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/RepositoryReference.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct RepositoryReference: Sendable, Equatable, Codable {
+    public let owner: String
+    public let name: String
+    public let defaultBranch: String
+
+    public init(owner: String, name: String, defaultBranch: String = "main") {
+        self.owner = owner
+        self.name = name
+        self.defaultBranch = defaultBranch
+    }
+
+    public var slug: String { "\(owner)/\(name)" }
+
+    public var browserURL: URL {
+        URL(string: "https://github.com/\(slug)")!
+    }
+
+    public var actionsURL: URL {
+        browserURL.appendingPathComponent("actions")
+    }
+
+    public static let homelab = RepositoryReference(
+        owner: "BenSuskins",
+        name: "homelab-ansible-plays"
+    )
+}
+
+/// The three destinations the menu links out to. Homepage stays the front door
+/// for the ~25 proxied services, so this list deliberately does not mirror it.
+public struct QuickLink: Sendable, Equatable, Identifiable {
+    public let title: String
+    public let symbolName: String
+    public let url: URL
+
+    public var id: String { url.absoluteString }
+
+    public static func standard(for repository: RepositoryReference) -> [QuickLink] {
+        [
+            QuickLink(
+                title: "Homepage",
+                symbolName: "house",
+                url: URL(string: "https://home.suskins.co.uk")!
+            ),
+            QuickLink(
+                title: "Actions",
+                symbolName: "play.rectangle",
+                url: repository.actionsURL
+            ),
+            QuickLink(
+                title: "Repo",
+                symbolName: "chevron.left.forwardslash.chevron.right",
+                url: repository.browserURL
+            ),
+        ]
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/RunStatus.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/RunStatus.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The state of the most recent run of a Dispatchable Workflow on `main`.
+public enum RunStatus: String, Equatable, Sendable, Codable {
+    /// The workflow has never run on `main`.
+    case never
+    case queued
+    case running
+    /// Parked at an environment gate, waiting for a required reviewer.
+    /// Terraform's apply stage does this on every run.
+    case awaitingApproval
+    case succeeded
+    case failed
+    case cancelled
+
+    /// GitHub splits this across two fields: a `status` that is only ever
+    /// `completed` for finished runs, and a `conclusion` that is null until then.
+    public init(status: String, conclusion: String?) {
+        switch status {
+        case "completed":
+            switch conclusion {
+            case "success", "skipped", "neutral": self = .succeeded
+            case "cancelled": self = .cancelled
+            case "action_required": self = .awaitingApproval
+            default: self = .failed
+            }
+        case "waiting", "pending", "action_required":
+            self = .awaitingApproval
+        case "in_progress":
+            self = .running
+        default:
+            self = .queued
+        }
+    }
+
+    /// Whether GitHub is currently doing work — the only condition that
+    /// justifies the fast polling interval.
+    public var isActive: Bool {
+        self == .queued || self == .running
+    }
+
+    /// A run that has not reached a conclusion still owns the workflow, so
+    /// starting another would race it.
+    public var isOpen: Bool {
+        isActive || self == .awaitingApproval
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/Summaries.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Domain/Summaries.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public struct WorkflowRunSummary: Equatable, Sendable, Codable {
+    public let identifier: Int
+    public let status: RunStatus
+    public let url: URL
+    public let startedAt: Date?
+    public let finishedAt: Date?
+
+    public init(
+        identifier: Int,
+        status: RunStatus,
+        url: URL,
+        startedAt: Date?,
+        finishedAt: Date?
+    ) {
+        self.identifier = identifier
+        self.status = status
+        self.url = url
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+    }
+
+    public func duration(now: Date) -> TimeInterval? {
+        guard let startedAt else { return nil }
+        let end = status.isOpen ? now : (finishedAt ?? now)
+        return max(0, end.timeIntervalSince(startedAt))
+    }
+}
+
+public enum MergeReadiness: String, Equatable, Sendable, Codable {
+    case mergeable
+    case conflicting
+    case unknown
+
+    init(mergeableField value: String) {
+        switch value.uppercased() {
+        case "MERGEABLE": self = .mergeable
+        case "CONFLICTING": self = .conflicting
+        default: self = .unknown
+        }
+    }
+}
+
+public struct PullRequestSummary: Equatable, Sendable, Codable, Identifiable {
+    public let number: Int
+    public let title: String
+    public let authorLogin: String
+    public let isDraft: Bool
+    public let readiness: MergeReadiness
+    public let createdAt: Date
+    public let url: URL
+
+    public var id: Int { number }
+
+    /// Merging pushes to `main`, which triggers Update Homelab — so the button
+    /// is only offered when GitHub is certain the merge will succeed.
+    public var canMerge: Bool {
+        readiness == .mergeable && !isDraft
+    }
+
+    public init(
+        number: Int,
+        title: String,
+        authorLogin: String,
+        isDraft: Bool,
+        readiness: MergeReadiness,
+        createdAt: Date,
+        url: URL
+    ) {
+        self.number = number
+        self.title = title
+        self.authorLogin = authorLogin
+        self.isDraft = isDraft
+        self.readiness = readiness
+        self.createdAt = createdAt
+        self.url = url
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/CommandRunner.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/CommandRunner.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+public enum CommandFailure: Error, Equatable, Sendable {
+    case executableNotFound(String)
+    case terminated(exitCode: Int32, standardError: String)
+}
+
+/// The single seam between this app and the outside world. Everything the app
+/// knows about GitHub arrives as bytes from a `gh` invocation, so faking this
+/// protocol fakes the entire network.
+public protocol CommandRunner: Sendable {
+    func run(_ arguments: [String]) async throws(CommandFailure) -> Data
+}
+
+public struct GitHubCommandLineRunner: CommandRunner {
+    private let executableURL: URL?
+
+    public init(executableURL: URL? = nil) {
+        self.executableURL = executableURL ?? Self.locateExecutable()
+    }
+
+    /// A GUI app inherits a minimal `PATH` that omits Homebrew and Nix, so the
+    /// usual `/usr/bin/env gh` trick finds nothing once the app is launched
+    /// from Finder rather than a shell.
+    static func locateExecutable() -> URL? {
+        let pathDirectories = (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+
+        let fallbackDirectories = [
+            "\(NSHomeDirectory())/.nix-profile/bin",
+            "/run/current-system/sw/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+        ]
+
+        let fileManager = FileManager.default
+        for directory in pathDirectories + fallbackDirectories {
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent("gh")
+            if fileManager.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    public func run(_ arguments: [String]) async throws(CommandFailure) -> Data {
+        guard let executableURL else {
+            throw .executableNotFound("gh")
+        }
+
+        let outcome = await Task.detached(priority: .utility) {
+            Self.invoke(executableURL: executableURL, arguments: arguments)
+        }.value
+
+        switch outcome {
+        case .success(let data):
+            return data
+        case .failure(let failure):
+            throw failure
+        }
+    }
+
+    private static func invoke(
+        executableURL: URL,
+        arguments: [String]
+    ) -> Result<Data, CommandFailure> {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+
+        // `gh` reads its own config, so it needs a HOME; it does not need a PATH.
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = NSHomeDirectory()
+        environment["GH_PROMPT_DISABLED"] = "1"
+        environment["NO_COLOR"] = "1"
+        process.environment = environment
+
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        do {
+            try process.run()
+        } catch {
+            return .failure(.executableNotFound(executableURL.path))
+        }
+
+        // Drain both pipes before waiting: a process that fills the 64KB pipe
+        // buffer blocks forever if we wait first and read second.
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let message = String(decoding: errorData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return .failure(.terminated(exitCode: process.terminationStatus, standardError: message))
+        }
+
+        return .success(outputData)
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/GitHubClient.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/GitHubClient.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public struct GitHubClient: Sendable {
+    private let runner: any CommandRunner
+    private let repository: RepositoryReference
+
+    public init(runner: any CommandRunner, repository: RepositoryReference = .homelab) {
+        self.runner = runner
+        self.repository = repository
+    }
+
+    // MARK: Reads
+
+    public func latestRun(
+        for workflow: DispatchableWorkflow
+    ) async throws(GitHubFailure) -> WorkflowRunSummary? {
+        let data = try await execute([
+            "api",
+            "repos/\(repository.slug)/actions/workflows/\(workflow.fileName)/runs"
+                + "?per_page=1&branch=\(repository.defaultBranch)",
+        ])
+
+        let payload = try decode(WorkflowRunListPayload.self, from: data)
+        guard let run = payload.workflowRuns.first else { return nil }
+
+        let status = RunStatus(status: run.status, conclusion: run.conclusion)
+        return WorkflowRunSummary(
+            identifier: run.identifier,
+            status: status,
+            url: run.url,
+            startedAt: run.startedAt,
+            finishedAt: status.isOpen ? nil : run.updatedAt
+        )
+    }
+
+    public func openPullRequests() async throws(GitHubFailure) -> [PullRequestSummary] {
+        let data = try await execute([
+            "pr", "list",
+            "--repo", repository.slug,
+            "--state", "open",
+            "--json", "number,title,author,isDraft,mergeable,createdAt,url",
+        ])
+
+        let payloads = try decode([PullRequestPayload].self, from: data)
+        return payloads.map { payload in
+            PullRequestSummary(
+                number: payload.number,
+                title: payload.title,
+                authorLogin: payload.author?.login ?? "ghost",
+                isDraft: payload.isDraft,
+                readiness: MergeReadiness(mergeableField: payload.mergeable),
+                createdAt: payload.createdAt,
+                url: payload.url
+            )
+        }
+    }
+
+    // MARK: Writes
+
+    public func dispatch(_ workflow: DispatchableWorkflow) async throws(GitHubFailure) {
+        _ = try await execute([
+            "api", "--method", "POST",
+            "repos/\(repository.slug)/actions/workflows/\(workflow.fileName)/dispatches",
+            "-f", "ref=\(repository.defaultBranch)",
+        ])
+    }
+
+    public func cancelRun(identifier: Int) async throws(GitHubFailure) {
+        _ = try await execute([
+            "api", "--method", "POST",
+            "repos/\(repository.slug)/actions/runs/\(identifier)/cancel",
+        ])
+    }
+
+    public func squashMerge(pullRequestNumber: Int) async throws(GitHubFailure) {
+        _ = try await execute([
+            "api", "--method", "PUT",
+            "repos/\(repository.slug)/pulls/\(pullRequestNumber)/merge",
+            "-f", "merge_method=squash",
+        ])
+    }
+
+    // MARK: Plumbing
+
+    private func execute(_ arguments: [String]) async throws(GitHubFailure) -> Data {
+        do {
+            return try await runner.run(arguments)
+        } catch {
+            throw GitHubFailure(error)
+        }
+    }
+
+    private func decode<Value: Decodable>(
+        _ type: Value.Type,
+        from data: Data
+    ) throws(GitHubFailure) -> Value {
+        do {
+            return try Self.decoder.decode(type, from: data)
+        } catch {
+            throw GitHubFailure.malformedResponse(String(describing: error))
+        }
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/GitHubFailure.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/GitHubFailure.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum GitHubFailure: Error, Equatable, Sendable {
+    case commandLineToolMissing
+    case notAuthenticated
+    case commandFailed(exitCode: Int32, message: String)
+    case malformedResponse(String)
+
+    init(_ failure: CommandFailure) {
+        switch failure {
+        case .executableNotFound:
+            self = .commandLineToolMissing
+        case .terminated(let exitCode, let standardError):
+            // `gh` exits 4 when the stored credentials are missing or expired.
+            if exitCode == 4 || standardError.localizedCaseInsensitiveContains("gh auth login") {
+                self = .notAuthenticated
+            } else {
+                self = .commandFailed(exitCode: exitCode, message: standardError)
+            }
+        }
+    }
+
+    public var displayMessage: String {
+        switch self {
+        case .commandLineToolMissing:
+            "`gh` not found — install the GitHub CLI"
+        case .notAuthenticated:
+            "Not signed in — run `gh auth login`"
+        case .commandFailed(_, let message):
+            message.isEmpty ? "GitHub command failed" : message
+        case .malformedResponse:
+            "Unexpected response from `gh`"
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/Payloads.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/GitHub/Payloads.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Wire shapes for the two `gh` invocations. These exist only to be decoded and
+/// immediately mapped onto domain types, so they stay file-private to the
+/// GitHub layer rather than leaking `html_url` upward.
+struct WorkflowRunListPayload: Decodable {
+    let workflowRuns: [WorkflowRunPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case workflowRuns = "workflow_runs"
+    }
+}
+
+struct WorkflowRunPayload: Decodable {
+    let identifier: Int
+    let status: String
+    let conclusion: String?
+    let url: URL
+    let startedAt: Date?
+    let updatedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case status
+        case conclusion
+        case url = "html_url"
+        case startedAt = "run_started_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+struct PullRequestPayload: Decodable {
+    struct Author: Decodable {
+        let login: String
+    }
+
+    let number: Int
+    let title: String
+    let author: Author?
+    let isDraft: Bool
+    let mergeable: String
+    let createdAt: Date
+    let url: URL
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/MenuSnapshot.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/MenuSnapshot.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// One row of the run list. Every question the view can ask — what colour, is
+/// the button enabled, what does the subtitle say — is answered here, so the
+/// view holds no logic and the logic needs no view to be tested.
+public struct RunRow: Equatable, Sendable, Codable, Identifiable {
+    public let workflow: DispatchableWorkflow
+    public let status: RunStatus
+    public let run: WorkflowRunSummary?
+
+    public var id: String { workflow.id }
+
+    public var canTrigger: Bool { !status.isOpen }
+    public var canCancel: Bool { status.isOpen }
+
+    public init(workflow: DispatchableWorkflow, run: WorkflowRunSummary?) {
+        self.workflow = workflow
+        self.run = run
+        self.status = run?.status ?? .never
+    }
+}
+
+/// An immutable description of everything the menu renders. Produced by a pure
+/// function from fetched data, consumed by SwiftUI, and persisted verbatim so
+/// the menu paints instantly at launch.
+public struct MenuSnapshot: Equatable, Sendable, Codable {
+    public var runRows: [RunRow]
+    public var pullRequests: [PullRequestSummary]
+    public var lastRefreshedAt: Date?
+    public var errorMessage: String?
+
+    public init(
+        runRows: [RunRow] = [],
+        pullRequests: [PullRequestSummary] = [],
+        lastRefreshedAt: Date? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.runRows = runRows
+        self.pullRequests = pullRequests
+        self.lastRefreshedAt = lastRefreshedAt
+        self.errorMessage = errorMessage
+    }
+
+    public var glyph: GlyphState {
+        GlyphState.worstOf(runRows.map(\.status))
+    }
+
+    public var hasActiveRun: Bool {
+        runRows.contains { $0.status.isActive }
+    }
+
+    public func row(for workflow: DispatchableWorkflow) -> RunRow? {
+        runRows.first { $0.workflow == workflow }
+    }
+
+    /// The empty menu shown before the first refresh lands, so the rows never
+    /// pop into existence one at a time.
+    public static var placeholder: MenuSnapshot {
+        MenuSnapshot(
+            runRows: DispatchableWorkflow.allCases.map { RunRow(workflow: $0, run: nil) }
+        )
+    }
+
+    public static func make(
+        runs: [DispatchableWorkflow: WorkflowRunSummary],
+        pullRequests: [PullRequestSummary],
+        lastRefreshedAt: Date?,
+        errorMessage: String? = nil
+    ) -> MenuSnapshot {
+        MenuSnapshot(
+            runRows: DispatchableWorkflow.allCases.map {
+                RunRow(workflow: $0, run: runs[$0])
+            },
+            pullRequests: pullRequests.sorted { $0.number > $1.number },
+            lastRefreshedAt: lastRefreshedAt,
+            errorMessage: errorMessage
+        )
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/MenuView.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/MenuView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+public struct MenuView: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.openURL) private var openURL
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().padding(.vertical, 6)
+
+            ForEach(state.snapshot.runRows) { row in
+                RunRowView(row: row)
+            }
+
+            Divider().padding(.vertical, 6)
+            pullRequestSection
+
+            Divider().padding(.vertical, 6)
+            quickLinkSection
+
+            if let errorMessage = state.snapshot.errorMessage {
+                Divider().padding(.vertical, 6)
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 4)
+            }
+
+            Divider().padding(.vertical, 6)
+            footer
+        }
+        .padding(.vertical, 8)
+        .frame(width: 320)
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Homelab")
+                .font(.headline)
+            Spacer()
+            if state.isRefreshing {
+                ProgressView().controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private var pullRequestSection: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Open PRs (\(state.snapshot.pullRequests.count))")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 2)
+
+            if state.snapshot.pullRequests.isEmpty {
+                Text("None")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 2)
+            } else {
+                ForEach(state.snapshot.pullRequests) { pullRequest in
+                    PullRequestRowView(pullRequest: pullRequest)
+                }
+            }
+        }
+    }
+
+    private var quickLinkSection: some View {
+        HStack(spacing: 4) {
+            ForEach(state.quickLinks) { link in
+                Button {
+                    openURL(link.url)
+                } label: {
+                    Label(link.title, systemImage: link.symbolName)
+                        .font(.caption)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private var footer: some View {
+        HStack {
+            if let lastRefreshedAt = state.snapshot.lastRefreshedAt {
+                Text("Updated \(RelativeTime.ago(lastRefreshedAt))")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Button("Refresh") {
+                Task { await state.refresh() }
+            }
+            .buttonStyle(.plain)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+            .buttonStyle(.plain)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/PollingSchedule.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/PollingSchedule.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Nothing changes for hours, then everything changes for four minutes — so the
+/// interval follows the work rather than the clock.
+public enum PollingSchedule {
+    public static let idle: Duration = .seconds(300)
+    public static let active: Duration = .seconds(10)
+
+    public static func interval(for snapshot: MenuSnapshot) -> Duration {
+        snapshot.hasActiveRun ? active : idle
+    }
+}
+
+/// Which runs newly reached a failed conclusion, and therefore deserve a
+/// notification. Comparing whole snapshots keeps this a pure function of two
+/// values rather than a pile of mutable "have I already told them" flags.
+public enum FailureDetector {
+    public static func newFailures(
+        previous: MenuSnapshot?,
+        current: MenuSnapshot
+    ) -> [RunRow] {
+        // Without a previous snapshot every existing failure looks new, which
+        // would fire a notification for last week's breakage on every launch.
+        guard let previous else { return [] }
+
+        return current.runRows.filter { row in
+            guard row.status == .failed, let run = row.run else { return false }
+
+            guard let earlier = previous.row(for: row.workflow), let earlierRun = earlier.run
+            else { return true }
+
+            return earlierRun.identifier != run.identifier || earlier.status != .failed
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/PullRequestRowView.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/PullRequestRowView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct PullRequestRowView: View {
+    let pullRequest: PullRequestSummary
+
+    @Environment(AppState.self) private var state
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: pullRequest.isDraft ? "circle.dashed" : "arrow.trianglehead.pull")
+                .foregroundStyle(pullRequest.isDraft ? Color.secondary : Color.green)
+                .frame(width: 16)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("#\(pullRequest.number) \(pullRequest.title)")
+                    .font(.system(size: 12))
+                    .lineLimit(2)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 4)
+
+            if state.isBusy(pullRequest: pullRequest.number) {
+                ProgressView().controlSize(.small)
+            } else if pullRequest.canMerge {
+                Button("Merge") {
+                    Task { await state.merge(pullRequest) }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Squash merge — this deploys")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 3)
+        .contentShape(.rect)
+        .onTapGesture { openURL(pullRequest.url) }
+    }
+
+    private var subtitle: String {
+        var parts = [pullRequest.authorLogin, RelativeTime.ago(pullRequest.createdAt)]
+        if pullRequest.isDraft {
+            parts.append("draft")
+        } else if pullRequest.readiness == .conflicting {
+            parts.append("conflicts")
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/RunRowView.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/RunRowView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct RunRowView: View {
+    let row: RunRow
+
+    @Environment(AppState.self) private var state
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: row.presentation.symbolName)
+                .foregroundStyle(row.presentation.tint)
+                .frame(width: 16)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(row.workflow.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                Text(row.subtitle())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if state.busyWorkflows.contains(row.workflow) {
+                ProgressView().controlSize(.small)
+            } else if state.canCancel(row.workflow) {
+                Button {
+                    Task { await state.cancel(row.workflow) }
+                } label: {
+                    Image(systemName: "stop.fill")
+                }
+                .buttonStyle(.borderless)
+                .help("Cancel this run")
+            } else {
+                Button {
+                    Task { await state.trigger(row.workflow) }
+                } label: {
+                    Image(systemName: "play.fill")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!state.canTrigger(row.workflow))
+                .help(row.workflow.summary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 3)
+        .contentShape(.rect)
+        .onTapGesture {
+            openURL(row.run?.url ?? state.repository.actionsURL)
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/RunStatusPresentation.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Menu/RunStatusPresentation.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// How each run state looks and reads. Kept beside the domain rather than
+/// inside the view so the whole vocabulary is visible in one place.
+public struct RunStatusPresentation: Sendable {
+    public let symbolName: String
+    public let tint: Color
+    public let label: String
+
+    public init(_ status: RunStatus) {
+        switch status {
+        case .never:
+            self.init(symbol: "minus.circle", tint: .secondary, label: "never run")
+        case .queued:
+            self.init(symbol: "clock", tint: .secondary, label: "queued")
+        case .running:
+            self.init(symbol: "circle.dotted", tint: .accentColor, label: "running")
+        case .awaitingApproval:
+            self.init(symbol: "pause.circle.fill", tint: .orange, label: "awaiting approval")
+        case .succeeded:
+            self.init(symbol: "checkmark.circle.fill", tint: .green, label: "passed")
+        case .failed:
+            self.init(symbol: "xmark.circle.fill", tint: .red, label: "failed")
+        case .cancelled:
+            self.init(symbol: "slash.circle", tint: .secondary, label: "cancelled")
+        }
+    }
+
+    private init(symbol: String, tint: Color, label: String) {
+        self.symbolName = symbol
+        self.tint = tint
+        self.label = label
+    }
+}
+
+extension RunRow {
+    public var presentation: RunStatusPresentation { RunStatusPresentation(status) }
+
+    /// "2h ago", "running · 3m 12s", "awaiting approval · plan ready".
+    public func subtitle(now: Date = Date()) -> String {
+        guard let run else { return "never run on main" }
+
+        switch status {
+        case .running, .queued:
+            let elapsed = run.duration(now: now).map(RelativeTime.duration) ?? "—"
+            return "\(presentation.label) · \(elapsed)"
+        case .awaitingApproval:
+            return "awaiting approval · plan ready"
+        default:
+            let when = (run.finishedAt ?? run.startedAt).map { RelativeTime.ago($0, now: now) }
+            let elapsed = run.duration(now: now).map(RelativeTime.duration)
+            return [presentation.label, when, elapsed]
+                .compactMap(\.self)
+                .joined(separator: " · ")
+        }
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/FailureNotifier.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/FailureNotifier.swift
@@ -1,0 +1,38 @@
+import Foundation
+import UserNotifications
+
+public protocol FailureNotifying: Sendable {
+    func requestAuthorization() async
+    func notify(_ row: RunRow) async
+}
+
+/// Success is the expected case and the glyph already reports it, so silence
+/// carries meaning: a notification only ever means something broke.
+public struct FailureNotifier: FailureNotifying {
+    public init() {}
+
+    public func requestAuthorization() async {
+        _ = try? await UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound])
+    }
+
+    public func notify(_ row: RunRow) async {
+        let content = UNMutableNotificationContent()
+        content.title = "\(row.workflow.displayName) Homelab failed"
+        content.body = row.run.map { run in
+            let elapsed = run.duration(now: Date()).map(RelativeTime.duration) ?? "—"
+            return "Failed after \(elapsed) · click to open the run"
+        } ?? "Click to open the run"
+        content.sound = .default
+        if let url = row.run?.url {
+            content.userInfo = ["url": url.absoluteString]
+        }
+
+        let request = UNNotificationRequest(
+            identifier: "run-failure-\(row.run?.identifier ?? 0)",
+            content: content,
+            trigger: nil
+        )
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/RelativeTime.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/RelativeTime.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum RelativeTime {
+    /// "2h ago", "3d ago" — deliberately coarse, because the menu answers
+    /// "recently or not" rather than "exactly when".
+    public static func ago(_ date: Date, now: Date = Date()) -> String {
+        let seconds = Int(max(0, now.timeIntervalSince(date)))
+        switch seconds {
+        case ..<60: return "just now"
+        case ..<3_600: return "\(seconds / 60)m ago"
+        case ..<86_400: return "\(seconds / 3_600)h ago"
+        default: return "\(seconds / 86_400)d ago"
+        }
+    }
+
+    /// "4m 01s" — used for run durations, where seconds genuinely matter
+    /// while you are watching one tick upward.
+    public static func duration(_ interval: TimeInterval) -> String {
+        let total = Int(max(0, interval))
+        let minutes = total / 60
+        let seconds = total % 60
+        if minutes == 0 { return "\(seconds)s" }
+        return String(format: "%dm %02ds", minutes, seconds)
+    }
+}

--- a/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/SnapshotCache.swift
+++ b/apps/homelab-menubar/Sources/HomelabMenuBarCore/Support/SnapshotCache.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Persists the last snapshot so the menu has something to draw the instant it
+/// opens after launch, rather than an empty box for the length of a round trip.
+public struct SnapshotCache: Sendable {
+    private let fileURL: URL
+
+    public init(fileURL: URL? = nil) {
+        self.fileURL = fileURL ?? Self.defaultFileURL()
+    }
+
+    static func defaultFileURL() -> URL {
+        let base = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+
+        return base
+            .appendingPathComponent("HomelabMenuBar", isDirectory: true)
+            .appendingPathComponent("snapshot.json")
+    }
+
+    public func load() -> MenuSnapshot? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? Self.decoder.decode(MenuSnapshot.self, from: data)
+    }
+
+    public func save(_ snapshot: MenuSnapshot) {
+        let directory = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        guard let data = try? Self.encoder.encode(snapshot) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/AppStateTests.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/AppStateTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import HomelabMenuBarCore
+
+final class RecordingNotifier: FailureNotifying, @unchecked Sendable {
+    private let lock = NSLock()
+    private var notified: [RunRow] = []
+
+    var notifiedWorkflows: [DispatchableWorkflow] {
+        lock.withLock { notified.map(\.workflow) }
+    }
+
+    func requestAuthorization() async {}
+
+    func notify(_ row: RunRow) async {
+        lock.withLock { notified.append(row) }
+    }
+}
+
+@MainActor
+@Suite("AppState")
+struct AppStateTests {
+    private func makeState(
+        _ runner: FakeCommandRunner,
+        notifier: RecordingNotifier = RecordingNotifier()
+    ) -> AppState {
+        AppState(
+            client: GitHubClient(runner: runner, repository: .homelab),
+            repository: .homelab,
+            cache: SnapshotCache(fileURL: temporaryCacheURL()),
+            notifier: notifier
+        )
+    }
+
+    private func temporaryCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("homelab-menubar-tests-\(UUID().uuidString)")
+            .appendingPathComponent("snapshot.json")
+    }
+
+    private func stubHealthyRepository(_ runner: FakeCommandRunner) {
+        for workflow in DispatchableWorkflow.allCases {
+            runner.stub(
+                containing: workflow.fileName,
+                json: Samples.workflowRuns(status: "completed", conclusion: "success")
+            )
+        }
+        runner.stub(containing: "pr", json: Samples.pullRequests)
+    }
+
+    @Test("shows a full set of rows before the first refresh lands")
+    func startsFromPlaceholder() {
+        let state = makeState(FakeCommandRunner())
+
+        #expect(state.snapshot.runRows.count == DispatchableWorkflow.allCases.count)
+        #expect(state.snapshot.glyph == .ok)
+    }
+
+    @Test("populates every row and the pull request list on refresh")
+    func refreshPopulatesSnapshot() async {
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner)
+
+        await state.refresh()
+
+        #expect(state.snapshot.row(for: .update)?.status == .succeeded)
+        #expect(state.snapshot.pullRequests.count == 2)
+        #expect(state.snapshot.lastRefreshedAt != nil)
+        #expect(state.snapshot.errorMessage == nil)
+    }
+
+    @Test("keeps the last good data on screen when a refresh fails")
+    func failedRefreshKeepsLastGoodData() async {
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner)
+        await state.refresh()
+
+        let failing = FakeCommandRunner()
+        failing.stub(containing: "update.yml", failure: .terminated(exitCode: 1, standardError: "boom"))
+        let degraded = AppState(
+            client: GitHubClient(runner: failing, repository: .homelab),
+            cache: SnapshotCache(fileURL: temporaryCacheURL()),
+            notifier: RecordingNotifier()
+        )
+        degraded.snapshot = state.snapshot
+
+        await degraded.refresh()
+
+        // The error is reported, but the rows survive rather than blanking.
+        #expect(degraded.snapshot.errorMessage != nil)
+        #expect(degraded.snapshot.row(for: .update)?.status == .succeeded)
+    }
+
+    @Test("refuses to trigger a workflow that already has an open run")
+    func refusesToTriggerAnOpenWorkflow() async {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "update.yml",
+            json: Samples.workflowRuns(status: "in_progress", conclusion: nil)
+        )
+        runner.stub(containing: "terraform.yml", json: Samples.noWorkflowRuns)
+        runner.stub(containing: "clean.yml", json: Samples.noWorkflowRuns)
+        runner.stub(containing: "pr", json: "[]")
+
+        let state = makeState(runner)
+        await state.refresh()
+        let readCount = runner.invocations.count
+
+        await state.trigger(.update)
+
+        // No dispatch was attempted at all — this is the guard that replaces a
+        // confirmation dialog.
+        #expect(state.canTrigger(.update) == false)
+        #expect(runner.invocations.count == readCount)
+    }
+
+    @Test("dispatches a workflow whose last run has settled")
+    func dispatchesSettledWorkflow() async {
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner)
+        await state.refresh()
+
+        await state.trigger(.clean)
+
+        #expect(runner.invokedArguments.contains { arguments in
+            arguments.contains("POST")
+                && arguments.contains { $0.hasSuffix("clean.yml/dispatches") }
+        })
+    }
+
+    @Test("notifies once when a workflow turns red")
+    func notifiesOnNewFailure() async {
+        let notifier = RecordingNotifier()
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner, notifier: notifier)
+        await state.refresh()
+
+        let failing = FakeCommandRunner()
+        failing.stub(
+            containing: "update.yml",
+            json: Samples.workflowRuns(identifier: 2002, status: "completed", conclusion: "failure")
+        )
+        failing.stub(containing: "terraform.yml", json: Samples.noWorkflowRuns)
+        failing.stub(containing: "clean.yml", json: Samples.noWorkflowRuns)
+        failing.stub(containing: "pr", json: "[]")
+
+        let second = AppState(
+            client: GitHubClient(runner: failing, repository: .homelab),
+            cache: SnapshotCache(fileURL: temporaryCacheURL()),
+            notifier: notifier
+        )
+        second.snapshot = state.snapshot
+        await second.refresh()
+
+        // Notifications are dispatched to a child task; give them a turn.
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(second.snapshot.glyph == .failed)
+        #expect(notifier.notifiedWorkflows == [.update])
+    }
+
+    @Test("will not merge a draft or a conflicting pull request")
+    func refusesUnmergeablePullRequests() async {
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner)
+        await state.refresh()
+
+        let draft = try! #require(state.snapshot.pullRequests.first { $0.number == 139 })
+        let readCount = runner.invocations.count
+
+        await state.merge(draft)
+
+        #expect(runner.invocations.count == readCount)
+    }
+
+    @Test("squash merges a ready pull request")
+    func mergesReadyPullRequest() async {
+        let runner = FakeCommandRunner()
+        stubHealthyRepository(runner)
+        let state = makeState(runner)
+        await state.refresh()
+
+        let ready = try! #require(state.snapshot.pullRequests.first { $0.number == 141 })
+        await state.merge(ready)
+
+        #expect(runner.invokedArguments.contains { $0.contains("merge_method=squash") })
+    }
+}
+
+@Suite("SnapshotCache")
+struct SnapshotCacheTests {
+    @Test("round-trips a snapshot so the menu paints instantly at launch")
+    func roundTripsSnapshot() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cache-test-\(UUID().uuidString)")
+            .appendingPathComponent("snapshot.json")
+        let cache = SnapshotCache(fileURL: url)
+
+        let original = MenuSnapshot.make(
+            runs: [.update: WorkflowRunSummary(
+                identifier: 7,
+                status: .failed,
+                url: URL(string: "https://github.com/x/y/actions/runs/7")!,
+                startedAt: Date(timeIntervalSince1970: 10),
+                finishedAt: Date(timeIntervalSince1970: 70)
+            )],
+            pullRequests: [],
+            lastRefreshedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        cache.save(original)
+
+        #expect(cache.load() == original)
+    }
+
+    @Test("returns nothing rather than throwing when no cache exists")
+    func missingCacheIsNotAnError() {
+        let cache = SnapshotCache(
+            fileURL: URL(fileURLWithPath: "/nonexistent/homelab/snapshot.json")
+        )
+
+        #expect(cache.load() == nil)
+    }
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/ContractTests.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/ContractTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import HomelabMenuBarCore
+
+/// The fakes above assert that our code handles `gh` output correctly. These
+/// assert that `gh` still *produces* that output — the one thing a fake can
+/// never tell us. Strictly read-only: no dispatch, no cancel, no merge.
+///
+/// Run with: `swift test --filter Contract`
+@Suite("Contract (real gh, read-only)", .tags(.contract))
+struct ContractTests {
+    private var client: GitHubClient {
+        GitHubClient(runner: GitHubCommandLineRunner(), repository: .homelab)
+    }
+
+    @Test("gh is installed and findable without a shell PATH")
+    func executableIsResolvable() throws {
+        let located = GitHubCommandLineRunner.locateExecutable()
+        try #require(located != nil, "gh not found — install the GitHub CLI")
+    }
+
+    @Test("the workflow runs endpoint still has the fields we decode")
+    func workflowRunsShapeIsStable() async throws {
+        let run = try await client.latestRun(for: .update)
+
+        let found = try #require(run, "Update Homelab has never run on main")
+        #expect(found.identifier > 0)
+        #expect(found.url.absoluteString.contains("/actions/runs/"))
+        #expect(found.startedAt != nil)
+    }
+
+    @Test("all three dispatchable workflows still exist in the repository")
+    func everyWorkflowResolves() async throws {
+        for workflow in DispatchableWorkflow.allCases {
+            // A missing workflow file makes `gh api` exit non-zero, which
+            // surfaces as a thrown GitHubFailure rather than an empty list.
+            _ = try await client.latestRun(for: workflow)
+        }
+    }
+
+    @Test("gh pr list still emits the JSON fields we ask for")
+    func pullRequestShapeIsStable() async throws {
+        let pullRequests = try await client.openPullRequests()
+
+        for pullRequest in pullRequests {
+            #expect(pullRequest.number > 0)
+            #expect(!pullRequest.title.isEmpty)
+            #expect(pullRequest.url.absoluteString.contains("/pull/"))
+            #expect(!pullRequest.authorLogin.isEmpty)
+        }
+    }
+}
+
+extension Tag {
+    @Tag static var contract: Self
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/FakeCommandRunner.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/FakeCommandRunner.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import HomelabMenuBarCore
+
+/// Stands in for `gh`. It records what was asked and replies with canned bytes,
+/// so every layer above it — decoding, mapping, snapshot building — runs for
+/// real in tests. Nothing is stubbed except the process boundary itself.
+final class FakeCommandRunner: CommandRunner, @unchecked Sendable {
+    struct Invocation: Equatable {
+        let arguments: [String]
+    }
+
+    private let lock = NSLock()
+    private var responses: [(matches: @Sendable ([String]) -> Bool, result: Result<Data, CommandFailure>)] = []
+    private var recorded: [Invocation] = []
+
+    var invocations: [Invocation] {
+        lock.withLock { recorded }
+    }
+
+    var invokedArguments: [[String]] {
+        invocations.map(\.arguments)
+    }
+
+    func stub(
+        containing fragment: String,
+        with data: Data
+    ) {
+        lock.withLock {
+            responses.append((
+                matches: { $0.contains { $0.contains(fragment) } },
+                result: .success(data)
+            ))
+        }
+    }
+
+    func stub(containing fragment: String, json: String) {
+        stub(containing: fragment, with: Data(json.utf8))
+    }
+
+    func stub(containing fragment: String, failure: CommandFailure) {
+        lock.withLock {
+            responses.append((
+                matches: { $0.contains { $0.contains(fragment) } },
+                result: .failure(failure)
+            ))
+        }
+    }
+
+    func run(_ arguments: [String]) async throws(CommandFailure) -> Data {
+        let result: Result<Data, CommandFailure> = lock.withLock {
+            recorded.append(Invocation(arguments: arguments))
+            let match = responses.first { $0.matches(arguments) }
+            return match?.result ?? .success(Data("[]".utf8))
+        }
+
+        switch result {
+        case .success(let data): return data
+        case .failure(let failure): throw failure
+        }
+    }
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/Fixtures/Samples.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/Fixtures/Samples.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Trimmed but otherwise verbatim `gh` output. Field names and value shapes
+/// match the real API so the decoding under test is the decoding that ships.
+enum Samples {
+    static func workflowRuns(
+        identifier: Int = 1001,
+        status: String,
+        conclusion: String?
+    ) -> String {
+        let conclusionField = conclusion.map { "\"\($0)\"" } ?? "null"
+        return """
+        {
+          "total_count": 1,
+          "workflow_runs": [
+            {
+              "id": \(identifier),
+              "name": "Update Homelab",
+              "head_branch": "main",
+              "status": "\(status)",
+              "conclusion": \(conclusionField),
+              "html_url": "https://github.com/BenSuskins/homelab-ansible-plays/actions/runs/\(identifier)",
+              "run_started_at": "2026-08-09T10:00:00Z",
+              "updated_at": "2026-08-09T10:04:01Z"
+            }
+          ]
+        }
+        """
+    }
+
+    static let noWorkflowRuns = """
+    { "total_count": 0, "workflow_runs": [] }
+    """
+
+    static let pullRequests = """
+    [
+      {
+        "number": 141,
+        "title": "chore(deps): update ansible docker images (major)",
+        "author": { "login": "app/renovate" },
+        "isDraft": false,
+        "mergeable": "MERGEABLE",
+        "createdAt": "2026-08-06T09:15:00Z",
+        "url": "https://github.com/BenSuskins/homelab-ansible-plays/pull/141"
+      },
+      {
+        "number": 139,
+        "title": "Add Faro frontend observability",
+        "author": null,
+        "isDraft": true,
+        "mergeable": "CONFLICTING",
+        "createdAt": "2026-08-01T09:15:00Z",
+        "url": "https://github.com/BenSuskins/homelab-ansible-plays/pull/139"
+      }
+    ]
+    """
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/GitHubClientTests.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/GitHubClientTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import HomelabMenuBarCore
+
+@Suite("GitHubClient")
+struct GitHubClientTests {
+    private func client(_ runner: FakeCommandRunner) -> GitHubClient {
+        GitHubClient(runner: runner, repository: .homelab)
+    }
+
+    @Test("decodes a completed successful run")
+    func decodesSuccessfulRun() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "update.yml",
+            json: Samples.workflowRuns(status: "completed", conclusion: "success")
+        )
+
+        let run = try await client(runner).latestRun(for: .update)
+
+        #expect(run?.status == .succeeded)
+        #expect(run?.identifier == 1001)
+        #expect(run?.finishedAt != nil)
+    }
+
+    @Test("maps GitHub's waiting status onto awaiting approval")
+    func mapsWaitingStatus() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "terraform.yml",
+            json: Samples.workflowRuns(status: "waiting", conclusion: nil)
+        )
+
+        let run = try await client(runner).latestRun(for: .terraform)
+
+        #expect(run?.status == .awaitingApproval)
+        // An unfinished run has no end, even though GitHub keeps stamping updated_at.
+        #expect(run?.finishedAt == nil)
+    }
+
+    @Test(
+        "maps every conclusion the API can return",
+        arguments: [
+            ("completed", "success", RunStatus.succeeded),
+            ("completed", "failure", RunStatus.failed),
+            ("completed", "timed_out", RunStatus.failed),
+            ("completed", "startup_failure", RunStatus.failed),
+            ("completed", "cancelled", RunStatus.cancelled),
+            ("completed", "skipped", RunStatus.succeeded),
+            ("in_progress", nil, RunStatus.running),
+            ("queued", nil, RunStatus.queued),
+            ("requested", nil, RunStatus.queued),
+        ]
+    )
+    func mapsConclusions(status: String, conclusion: String?, expected: RunStatus) async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "update.yml",
+            json: Samples.workflowRuns(status: status, conclusion: conclusion)
+        )
+
+        let run = try await client(runner).latestRun(for: .update)
+
+        #expect(run?.status == expected)
+    }
+
+    @Test("a workflow that never ran yields no run")
+    func handlesNeverRun() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(containing: "clean.yml", json: Samples.noWorkflowRuns)
+
+        let run = try await client(runner).latestRun(for: .clean)
+
+        #expect(run == nil)
+    }
+
+    @Test("asks only for the latest run on the default branch")
+    func queriesLatestRunOnDefaultBranch() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "update.yml",
+            json: Samples.workflowRuns(status: "completed", conclusion: "success")
+        )
+
+        _ = try await client(runner).latestRun(for: .update)
+
+        let arguments = try #require(runner.invokedArguments.first)
+        #expect(arguments.contains { $0.contains("per_page=1") })
+        #expect(arguments.contains { $0.contains("branch=main") })
+    }
+
+    @Test("decodes pull requests including a null author and a draft")
+    func decodesPullRequests() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(containing: "pr", json: Samples.pullRequests)
+
+        let pullRequests = try await client(runner).openPullRequests()
+
+        #expect(pullRequests.count == 2)
+        #expect(pullRequests[0].number == 141)
+        #expect(pullRequests[0].authorLogin == "app/renovate")
+        #expect(pullRequests[0].readiness == .mergeable)
+        #expect(pullRequests[0].canMerge)
+
+        // A null author decodes rather than throwing, and a conflicting draft
+        // must never offer a merge button.
+        #expect(pullRequests[1].authorLogin == "ghost")
+        #expect(pullRequests[1].readiness == .conflicting)
+        #expect(pullRequests[1].canMerge == false)
+    }
+
+    @Test("dispatches against the default branch")
+    func dispatchesWorkflow() async throws {
+        let runner = FakeCommandRunner()
+
+        try await client(runner).dispatch(.clean)
+
+        let arguments = try #require(runner.invokedArguments.first)
+        #expect(arguments.contains("POST"))
+        #expect(arguments.contains("repos/BenSuskins/homelab-ansible-plays/actions/workflows/clean.yml/dispatches"))
+        #expect(arguments.contains("ref=main"))
+    }
+
+    @Test("merges by squashing")
+    func squashMerges() async throws {
+        let runner = FakeCommandRunner()
+
+        try await client(runner).squashMerge(pullRequestNumber: 141)
+
+        let arguments = try #require(runner.invokedArguments.first)
+        #expect(arguments.contains("PUT"))
+        #expect(arguments.contains("merge_method=squash"))
+        #expect(arguments.contains("repos/BenSuskins/homelab-ansible-plays/pulls/141/merge"))
+    }
+
+    @Test("reports a missing gh binary as a distinct failure")
+    func reportsMissingExecutable() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(containing: "update.yml", failure: .executableNotFound("gh"))
+
+        await #expect(throws: GitHubFailure.commandLineToolMissing) {
+            try await client(runner).latestRun(for: .update)
+        }
+    }
+
+    @Test("recognises an expired login rather than reporting a generic failure")
+    func recognisesLoggedOutState() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(
+            containing: "update.yml",
+            failure: .terminated(exitCode: 4, standardError: "gh auth login required")
+        )
+
+        await #expect(throws: GitHubFailure.notAuthenticated) {
+            try await client(runner).latestRun(for: .update)
+        }
+    }
+
+    @Test("surfaces unparseable output instead of crashing")
+    func surfacesMalformedOutput() async throws {
+        let runner = FakeCommandRunner()
+        runner.stub(containing: "update.yml", json: "not json at all")
+
+        await #expect(throws: GitHubFailure.self) {
+            try await client(runner).latestRun(for: .update)
+        }
+    }
+}

--- a/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/MenuSnapshotTests.swift
+++ b/apps/homelab-menubar/Tests/HomelabMenuBarCoreTests/MenuSnapshotTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+@testable import HomelabMenuBarCore
+
+private func run(
+    identifier: Int = 1,
+    _ status: RunStatus,
+    startedAt: Date? = Date(timeIntervalSince1970: 0),
+    finishedAt: Date? = nil
+) -> WorkflowRunSummary {
+    WorkflowRunSummary(
+        identifier: identifier,
+        status: status,
+        url: URL(string: "https://github.com/x/y/actions/runs/\(identifier)")!,
+        startedAt: startedAt,
+        finishedAt: finishedAt
+    )
+}
+
+@Suite("MenuSnapshot")
+struct MenuSnapshotTests {
+    @Test("always renders every dispatchable workflow, even one that never ran")
+    func rendersEveryWorkflow() {
+        let snapshot = MenuSnapshot.make(
+            runs: [.update: run(.succeeded)],
+            pullRequests: [],
+            lastRefreshedAt: nil
+        )
+
+        #expect(snapshot.runRows.count == DispatchableWorkflow.allCases.count)
+        #expect(snapshot.row(for: .clean)?.status == .never)
+    }
+
+    @Test("orders pull requests newest first")
+    func ordersPullRequestsNewestFirst() {
+        let snapshot = MenuSnapshot.make(
+            runs: [:],
+            pullRequests: [pullRequest(number: 12), pullRequest(number: 141)],
+            lastRefreshedAt: nil
+        )
+
+        #expect(snapshot.pullRequests.map(\.number) == [141, 12])
+    }
+
+    @Test("a workflow with an open run cannot be triggered but can be cancelled")
+    func openRunBlocksTrigger() {
+        let running = RunRow(workflow: .update, run: run(.running))
+
+        #expect(running.canTrigger == false)
+        #expect(running.canCancel)
+    }
+
+    @Test("a run parked at the approval gate still owns the workflow")
+    func awaitingApprovalBlocksTrigger() {
+        let parked = RunRow(workflow: .terraform, run: run(.awaitingApproval))
+
+        // Nothing is executing, but dispatching again would race the parked run.
+        #expect(parked.canTrigger == false)
+        #expect(parked.canCancel)
+    }
+
+    @Test("a settled workflow can be triggered and cannot be cancelled")
+    func settledRunAllowsTrigger() {
+        for status in [RunStatus.succeeded, .failed, .cancelled, .never] {
+            let row = RunRow(workflow: .clean, run: status == .never ? nil : run(status))
+            #expect(row.canTrigger, "\(status) should allow a trigger")
+            #expect(row.canCancel == false, "\(status) should not offer a cancel")
+        }
+    }
+
+    private func pullRequest(number: Int) -> PullRequestSummary {
+        PullRequestSummary(
+            number: number,
+            title: "Title \(number)",
+            authorLogin: "BenSuskins",
+            isDraft: false,
+            readiness: .mergeable,
+            createdAt: Date(timeIntervalSince1970: 0),
+            url: URL(string: "https://github.com/x/y/pull/\(number)")!
+        )
+    }
+}
+
+@Suite("GlyphState")
+struct GlyphStateTests {
+    @Test("a failure outranks everything else")
+    func failureWins() {
+        #expect(GlyphState.worstOf([.succeeded, .running, .failed]) == .failed)
+    }
+
+    @Test("an active run outranks success")
+    func runningBeatsSuccess() {
+        #expect(GlyphState.worstOf([.succeeded, .queued, .succeeded]) == .running)
+    }
+
+    @Test("all quiet reads as ok")
+    func quietIsOk() {
+        #expect(GlyphState.worstOf([.succeeded, .never, .cancelled]) == .ok)
+    }
+
+    @Test("a run parked at the approval gate does not raise the glyph")
+    func awaitingApprovalIsNotAnAlarm() {
+        // A deliberate consequence of notifying on failure only: a parked plan
+        // waits quietly rather than nagging.
+        #expect(GlyphState.worstOf([.succeeded, .awaitingApproval]) == .ok)
+    }
+}
+
+@Suite("PollingSchedule")
+struct PollingScheduleTests {
+    @Test("tightens the interval while GitHub is doing work")
+    func fastWhileActive() {
+        let snapshot = MenuSnapshot.make(
+            runs: [.update: run(.running)],
+            pullRequests: [],
+            lastRefreshedAt: nil
+        )
+
+        #expect(PollingSchedule.interval(for: snapshot) == PollingSchedule.active)
+    }
+
+    @Test("relaxes the interval when nothing is running")
+    func slowWhenIdle() {
+        let snapshot = MenuSnapshot.make(
+            runs: [.update: run(.succeeded)],
+            pullRequests: [],
+            lastRefreshedAt: nil
+        )
+
+        #expect(PollingSchedule.interval(for: snapshot) == PollingSchedule.idle)
+    }
+
+    @Test("a run awaiting approval does not warrant fast polling")
+    func approvalGateDoesNotPoll() {
+        // It will sit there until a human acts, so polling it every 10s is waste.
+        let snapshot = MenuSnapshot.make(
+            runs: [.terraform: run(.awaitingApproval)],
+            pullRequests: [],
+            lastRefreshedAt: nil
+        )
+
+        #expect(PollingSchedule.interval(for: snapshot) == PollingSchedule.idle)
+    }
+}
+
+@Suite("FailureDetector")
+struct FailureDetectorTests {
+    private func snapshot(_ workflow: DispatchableWorkflow, _ summary: WorkflowRunSummary) -> MenuSnapshot {
+        MenuSnapshot.make(runs: [workflow: summary], pullRequests: [], lastRefreshedAt: nil)
+    }
+
+    @Test("stays silent on first launch, however bad the news")
+    func silentWithoutHistory() {
+        let current = snapshot(.update, run(.failed))
+
+        // Without a previous snapshot, last week's breakage would look new and
+        // fire a notification every single launch.
+        #expect(FailureDetector.newFailures(previous: nil, current: current).isEmpty)
+    }
+
+    @Test("reports a run that has just turned red")
+    func reportsFreshFailure() {
+        let previous = snapshot(.update, run(identifier: 1, .running))
+        let current = snapshot(.update, run(identifier: 1, .failed))
+
+        #expect(FailureDetector.newFailures(previous: previous, current: current).count == 1)
+    }
+
+    @Test("does not report the same failure twice")
+    func doesNotRepeatItself() {
+        let previous = snapshot(.update, run(identifier: 1, .failed))
+        let current = snapshot(.update, run(identifier: 1, .failed))
+
+        #expect(FailureDetector.newFailures(previous: previous, current: current).isEmpty)
+    }
+
+    @Test("reports a second failed run of the same workflow")
+    func reportsRepeatFailureFromANewRun() {
+        let previous = snapshot(.update, run(identifier: 1, .failed))
+        let current = snapshot(.update, run(identifier: 2, .failed))
+
+        // Same workflow, same colour, different run — you broke it again.
+        #expect(FailureDetector.newFailures(previous: previous, current: current).count == 1)
+    }
+
+    @Test("says nothing when a run succeeds")
+    func silentOnSuccess() {
+        let previous = snapshot(.update, run(identifier: 1, .running))
+        let current = snapshot(.update, run(identifier: 1, .succeeded))
+
+        #expect(FailureDetector.newFailures(previous: previous, current: current).isEmpty)
+    }
+}
+
+@Suite("Run durations and relative time")
+struct RelativeTimeTests {
+    @Test("an open run measures against now, not its stale updated_at")
+    func openRunMeasuresAgainstNow() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let summary = run(.running, startedAt: start, finishedAt: nil)
+
+        let elapsed = summary.duration(now: Date(timeIntervalSince1970: 1_190))
+
+        #expect(elapsed == 190)
+    }
+
+    @Test("a finished run measures to its conclusion")
+    func finishedRunMeasuresToConclusion() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let summary = run(.succeeded, startedAt: start, finishedAt: Date(timeIntervalSince1970: 1_241))
+
+        let elapsed = summary.duration(now: Date(timeIntervalSince1970: 99_999))
+
+        #expect(elapsed == 241)
+    }
+
+    @Test("formats durations with minutes and padded seconds")
+    func formatsDuration() {
+        #expect(RelativeTime.duration(241) == "4m 01s")
+        #expect(RelativeTime.duration(45) == "45s")
+    }
+
+    @Test("formats ages coarsely")
+    func formatsAge() {
+        let now = Date(timeIntervalSince1970: 100_000)
+        #expect(RelativeTime.ago(now.addingTimeInterval(-30), now: now) == "just now")
+        #expect(RelativeTime.ago(now.addingTimeInterval(-600), now: now) == "10m ago")
+        #expect(RelativeTime.ago(now.addingTimeInterval(-7_200), now: now) == "2h ago")
+        #expect(RelativeTime.ago(now.addingTimeInterval(-259_200), now: now) == "3d ago")
+    }
+}

--- a/docs/adr/0003-menu-bar-app-lives-in-this-repo.md
+++ b/docs/adr/0003-menu-bar-app-lives-in-this-repo.md
@@ -1,0 +1,37 @@
+# The menu bar app lives in this repo, which constrains two workflows
+
+`apps/homelab-menubar/` is a native macOS SwiftUI application — a Swift package
+with its own `Makefile` and test suite — sitting inside a repository that is
+otherwise entirely Ansible, Terraform and Jinja. It exists to drive this
+repository's three dispatchable workflows (`update.yml`, `terraform.yml`,
+`clean.yml`), read open pull requests, and link out to Homepage.
+
+Decided: it stays here rather than in a separate `homelab-menubar` repository,
+because the app is a control surface for *this* repo's CI/CD and nothing else —
+its `DispatchableWorkflow` enum is literally a list of files in
+`.github/workflows/`. Splitting them puts a hard coupling across a repo
+boundary where nothing can enforce it.
+
+**The cost is a coupling that is invisible from the app's side and destructive
+if forgotten.** `update.yml` and `build-mcp-arr.yml` both trigger on every push
+to `main` with no path filter. Without `paths-ignore: ['apps/**']` on both, a
+commit that only touches Swift source runs Ansible against all six hosts and
+rebuilds the MCP images. Those two `paths-ignore` blocks are load-bearing:
+deleting one looks like tidying and behaves like an accidental deploy on every
+future app commit.
+
+Adopting the app also forced two unrelated fixes, because a menu bar button
+makes dispatching cheap enough to do twice by accident. `clean.yml` and
+`terraform.yml` had no `concurrency` group, and the three Terraform R2 backends
+had no state locking (`use_lockfile` unset, no DynamoDB table) — so two
+concurrent applies could corrupt state. Both are now fixed at the source rather
+than guarded in the app, so pushes and bare `gh` invocations are protected too.
+The app additionally disables its trigger button while a run is open, but that
+is defence in depth, not the mechanism.
+
+The alternatives were a separate repository, which removes the `paths-ignore`
+trap entirely but leaves the workflow-file coupling unenforceable and undiscovered
+until something breaks; and a local-only checkout with no remote, which loses
+history and a second machine. Neither addressed the concurrency and locking gaps,
+which were latent in the repository before this app existed and were only found
+because dispatching became a one-click operation.

--- a/plans/homelab-menubar.md
+++ b/plans/homelab-menubar.md
@@ -1,0 +1,99 @@
+# Homelab Menu Bar App
+
+**Status:** v1 built and passing (2026-08-09)
+**Location:** `apps/homelab-menubar/`
+
+A macOS menu bar app for driving this repository's CI/CD: workflow state,
+triggers, open PRs, and three quick links.
+
+## Scope
+
+v1 is **GitHub only** — no Gatus, no Prometheus, no tailnet dependency, so it
+works away from the LAN. Service health and host vitals were considered and
+deliberately deferred; Grafana and Gatus already answer those questions better
+than a 320px popover can.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scope | GitHub CI/CD only | Works anywhere; no network dependency on the homelab |
+| Stack | SwiftUI `MenuBarExtra(.window)` | One flat panel for one repo; no AppKit menu machinery needed |
+| Auth | Shell out to `gh` | Existing keyring login already has `repo` scope; no token code at all |
+| Repo | `apps/` in this repo | See ADR 0003 — requires `paths-ignore` on two workflows |
+| Build | SwiftPM + `Makefile` | `swift test` is a sub-second TDD loop; all text in git |
+| Trigger guard | None — fires immediately | Disabled-while-open + workflow `concurrency` covers the real hazard |
+| Terraform gate | Surface + deep link | Approving a plan you cannot see is a slower auto-apply |
+| Polling | Adaptive 300s / 10s | Nothing changes for hours, then everything changes for four minutes |
+| Glyph | Worst-of failure > running > ok | Answers one question: "do I need to open this?" |
+| PRs | List, click to open, squash merge | Merge is deploy: one commit on main = one Update run |
+| Quick links | Homepage, Actions, Repo | Homepage is already the link dashboard for the other ~25 services |
+| Notifications | Failure only | Silence carries meaning |
+| Errors | Typed throws | Same exhaustiveness as `Result`, composes with `async`/`await` |
+| Test seam | Fake `CommandRunner` + contract tests | Decoding — the layer most likely to break — stays under test |
+
+Rejected: Tauri/Electron/xbar (wrong weight), `NSStatusItem`+`NSMenu` (RepoBar
+needs it for nested per-repo submenus; this app has one flat panel), Bazel
+(~80 lines of config and a new toolchain for one target), a separate repo,
+generating links from Service Entries (a YAML+Jinja parser in Swift to rebuild
+Homepage), local checkout state (different question from "what is the homelab
+doing").
+
+## Repository changes this required
+
+These are the point of ADR 0003 and must not be reverted casually:
+
+1. `paths-ignore: ['apps/**']` on `update.yml` **and** `build-mcp-arr.yml` —
+   both trigger on every push to `main` with no path filter, so without this a
+   commit to Swift code runs Ansible against all six hosts.
+2. `concurrency` groups on `clean.yml` and `terraform.yml`. `update.yml` already
+   had one; the other two did not.
+3. `use_lockfile = true` on all three `backend "s3"` blocks. R2 has no DynamoDB
+   table, so Terraform state was entirely unlocked — two concurrent applies
+   could corrupt it.
+
+## Architecture
+
+```
+GitHubCommandLineRunner   ← the only impure thing; spawns `gh`
+      ↓ Data
+GitHubClient              ← decodes, maps onto domain types
+      ↓ WorkflowRunSummary / PullRequestSummary
+AppState                  ← @Observable, owns the polling loop
+      ↓ MenuSnapshot      ← immutable; also what gets cached to disk
+MenuView
+```
+
+`MenuSnapshot` is the seam, borrowed from
+[RepoBar](https://github.com/steipete/RepoBar)'s `MenuSnapshot.swift`. It
+answers every question the view can ask, so the view holds no logic and the
+logic needs no view to test. Also borrowed: splitting `AppState` by concern
+across files, and caching the last snapshot so the menu paints instantly.
+
+## Test coverage
+
+42 unit tests against a fake `CommandRunner` (decoding, status mapping, glyph
+collapse, polling cadence, failure detection, trigger/merge guards, cache round
+trip) and 4 read-only contract tests against real `gh`.
+
+```bash
+swift test --skip Contract    # fakes only
+swift test --filter Contract  # real gh, read-only
+```
+
+## Known gaps
+
+- **A run parked at the approval gate is invisible from the closed menu.** The
+  glyph stays `ok` and no notification fires. This follows from choosing
+  "notify on failure only" over "failure + awaiting approval" — a parked plan
+  waits quietly. Revisit if a plan ever sits forgotten for days.
+- **The popover UI has not been visually verified** — screen recording
+  permission was unavailable during the build.
+- **Launch at login is manual** (System Settings → Login Items) rather than an
+  in-app `SMAppService` toggle.
+
+## Possible v2
+
+Gatus service health (needs LAN/tailnet), per-host vitals from Prometheus,
+approve-with-plan-summary for Terraform, local checkout state, a settings pane
+for the link list.

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10"
 
   required_providers {
     cloudflare = {
@@ -24,6 +24,7 @@ terraform {
     skip_region_validation      = true
     skip_s3_checksum            = true
     use_path_style              = true
+    use_lockfile                = true
   }
 }
 

--- a/terraform/proxmox/main.tf
+++ b/terraform/proxmox/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10"
 
   required_providers {
     proxmox = {
@@ -24,6 +24,7 @@ terraform {
     skip_region_validation      = true
     skip_s3_checksum            = true
     use_path_style              = true
+    use_lockfile                = true
   }
 }
 

--- a/terraform/tailscale/main.tf
+++ b/terraform/tailscale/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10"
 
   required_providers {
     tailscale = {
@@ -24,6 +24,7 @@ terraform {
     skip_region_validation      = true
     skip_s3_checksum            = true
     use_path_style              = true
+    use_lockfile                = true
   }
 }
 


### PR DESCRIPTION
A native SwiftUI menu bar app at `apps/homelab-menubar/` for driving this repo's CI/CD.

```
⚙  ← glyph: worst-of (⚠ failed > ◐ running > ⚙ ok)
┌──────────────────────────────┐
│ Update      ✓ passed · 2h ago│  [▶]
│ Terraform   ⏸ awaiting appr… │
│ Clean       ◐ running · 3m12s│  [■]
│ ──────────────────────────── │
│ Open PRs (1)                 │
│  #141 chore(deps): ansible…  │  [Merge]
│ ──────────────────────────── │
│ Homepage ↗  Actions ↗  Repo ↗│
└──────────────────────────────┘
```

`make install` → `/Applications/Homelab.app`. Verified running against the real repo.

## How it works

Authenticates by shelling out to `gh`, so it stores no token, has no Keychain code and no OAuth flow — `gh auth login` is the entire credential story. `gh` is resolved from Nix/Homebrew paths explicitly, since a Finder-launched app doesn't inherit your shell `PATH`.

```
GitHubCommandLineRunner   ← the only impure thing; spawns `gh`
      ↓ Data
GitHubClient              ← decodes, maps onto domain types
      ↓ WorkflowRunSummary / PullRequestSummary
AppState                  ← @Observable, owns the polling loop
      ↓ MenuSnapshot      ← immutable; also what gets cached to disk
MenuView
```

`MenuSnapshot` is the seam: it answers every question the view can ask — row colour, button enabled, subtitle text — so the view holds no logic and the logic needs no view to test.

Polling is adaptive: 300s idle, 10s while a run is active, immediate on menu open and after a dispatch. The last snapshot is cached to disk so the menu paints instantly at launch.

## Repository changes (the important part of this PR)

1. **`paths-ignore: ['apps/**']` on `update.yml` and `build-mcp-arr.yml`.** Both trigger on every push to `main` with no path filter. Without this, a commit touching only Swift code runs Ansible against all six hosts. These blocks are load-bearing — see ADR 0003.
2. **`concurrency` groups on `clean.yml` and `terraform.yml`**, which had none (`update.yml` already did).
3. **`use_lockfile = true` on all three R2 backends.** They had no state locking whatsoever — no DynamoDB table, `use_lockfile` unset — so two concurrent applies could corrupt state. Needs Terraform ≥ 1.10, so `required_version` moves from `>= 1.6` to match.

(2) and (3) were latent before this app existed. They surfaced because a menu bar button makes dispatching cheap enough to do twice by accident.

## Deliberate choices

- **No confirmation on trigger.** The guard is that `▶` is disabled while a run is open, backed by the workflow-level concurrency groups above.
- **The app never approves a deployment.** Terraform parks at its `required_reviewers` gate; the row says so and links to the run where the plan is. Approving a plan you can't see is a slower auto-apply.
- **Notify on failure only** — success is expected and the glyph already reports it, so a notification always means something broke.
- **Squash merge, always.** Merging here deploys: one commit on `main` = one Update run = one line in the deploy log.
- **Quick links are just Homepage / Actions / Repo.** Homepage is already the link dashboard for the other ~25 services; duplicating it in a popover would be a worse second copy.

## Tests

46 passing — 42 against a fake `CommandRunner` (decoding, status mapping, glyph collapse, polling cadence, failure detection, trigger/merge guards, cache round-trip) and 4 read-only contract tests against real `gh`.

```bash
swift test --skip Contract    # fakes only, no network
swift test --filter Contract  # real gh, read-only
```

## Known gaps

- A run parked at the approval gate is invisible from the closed menu — the glyph stays `ok` and nothing notifies. Direct consequence of "notify on failure only"; a parked plan waits quietly.
- Launch at login is manual (System Settings → Login Items) rather than an in-app `SMAppService` toggle.

Design rationale in `plans/homelab-menubar.md`, the repo-coupling decision in `docs/adr/0003-menu-bar-app-lives-in-this-repo.md`, and five new glossary terms in `CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUvrkFeNzrJp7xKyKMuKF7
